### PR TITLE
feat(auth): add setup wizard and startup auth check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,17 +7,27 @@ LOG_LEVEL=debug
 DATA_DIR=./backend/data
 
 # ── Authentication ───────────────────────────────────────────
-# FlowBoost uses the Claude Agent SDK, which runs Claude Code CLI
-# as a subprocess. The CLI needs credentials to call the Anthropic API.
+# FlowBoost uses the Claude Agent SDK, which spawns Claude Code CLI
+# as a subprocess. The CLI picks up credentials in this order:
+#   1. ANTHROPIC_API_KEY  — Console API key (pay-per-use)
+#   2. ANTHROPIC_AUTH_TOKEN — OAuth access token (from Max subscription)
+#   3. ~/.claude/.credentials.json — CLI OAuth credentials (via claude login)
 #
-# Option 1: API Key (recommended)
+# Choose ONE of the following:
+#
+# Option 1: API Key (pay-per-use)
 #   Get a key at https://console.anthropic.com
 ANTHROPIC_API_KEY=
 #
-# Option 2: Claude Code CLI credentials (Max subscription)
-#   If you're logged in via `claude` CLI and have a Max subscription,
-#   mount your credentials into the container instead of setting an API key.
-#   See docker-compose.override.example.yml for details.
+# Option 2: OAuth Token (Max subscription)
+#   Paste your access token from ~/.claude/.credentials.json (Linux)
+#   or extract it from macOS Keychain. Expires after a few months.
+# ANTHROPIC_AUTH_TOKEN=
+#
+# Option 3: CLI Login (Max subscription, recommended)
+#   Leave both empty. Set up a persistent volume and run `claude login`
+#   inside the container. The CLI handles token refresh automatically.
+#   See docker-compose.override.example.yml for setup.
 
 # ── Image Generation (optional) ──────────────────────────────
 # Google Gemini — powers hero image generation via Imagen 4.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,10 @@ FlowBoost uses the [Claude Agent SDK](https://docs.anthropic.com/en/docs/agents/
 git clone https://github.com/johrld/flowboost.git
 cd flowboost
 
-# 2. Configure environment
-cp .env.example .env
-# Edit .env and set ANTHROPIC_API_KEY
-
-# 3. Initialize seed data
+# 2. Run setup (creates .env, configures auth, seeds data)
 bash scripts/setup.sh
 
-# 4. Start services
+# 3. Start services
 docker compose up --build
 ```
 
@@ -73,37 +69,77 @@ The API runs at [http://localhost:6100](http://localhost:6100).
 
 ## Authentication
 
-The Claude Agent SDK runs Claude Code CLI as a subprocess. The CLI needs credentials to call the Anthropic API.
+The Claude Agent SDK spawns Claude Code CLI as a subprocess. The CLI picks up credentials from environment variables or its own credential store — no auth code needed in the application.
 
-### Option 1: API Key (recommended)
+```
+.env (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)
+  → docker-compose.yml (env_file: .env)
+    → Container process.env
+      → Agent SDK query() spawns CLI subprocess (inherits env)
+        → CLI authenticates with Anthropic API
+```
 
-Set `ANTHROPIC_API_KEY` in your `.env` file. This is the simplest setup.
+### Option 1: API Key (pay-per-use)
+
+Set `ANTHROPIC_API_KEY` in your `.env` file. Requires a [Console account](https://console.anthropic.com) with credits.
 
 ```bash
 # .env
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-### Option 2: Claude CLI Credentials (Max subscription)
+### Option 2: OAuth Token (Max subscription)
 
-If you have a Claude Max subscription and are logged into the CLI (`claude login`), mount your credentials into the container:
+If you have a Claude Max subscription, paste your OAuth access token directly. No volume mounts needed.
+
+On **Linux**, extract the token from:
+```bash
+cat ~/.claude/.credentials.json | grep accessToken
+```
+
+On **macOS**, the CLI stores credentials in the Keychain, not as files. You can extract the token via Keychain Access or use Option 3 instead.
 
 ```bash
-# Copy the override template
+# .env
+ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-...
+```
+
+> **Note:** The access token expires after a few months. When it does, you need to paste a fresh one. For automatic refresh, use Option 3.
+
+### Option 3: CLI Login (Max subscription, recommended)
+
+Authenticate the CLI inside the container using a persistent Docker volume. The CLI stores both access and refresh tokens, so credentials renew automatically.
+
+```bash
+# 1. Copy the override template
 cp docker-compose.override.example.yml docker-compose.override.yml
 ```
 
-Uncomment the volume mounts in `docker-compose.override.yml`:
+Uncomment the named volume in `docker-compose.override.yml`:
 
 ```yaml
 services:
   api:
     volumes:
-      - ~/.claude.json:/root/.claude.json:ro
-      - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+      - claude-credentials:/root/.claude
+
+volumes:
+  claude-credentials:
 ```
 
-Leave `ANTHROPIC_API_KEY` empty in `.env` — the CLI will use its own credentials.
+```bash
+# 2. Start services
+docker compose up --build -d
+
+# 3. Authenticate once inside the container
+docker compose exec api claude login
+```
+
+Credentials persist in the Docker volume across container rebuilds. Leave `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` empty in `.env`.
+
+> **Why not mount `~/.claude/` from the host?** On macOS, the CLI stores credentials in the Keychain, not as files — there's nothing to mount. The named volume approach works on all operating systems.
+>
+> **Heads up:** `docker compose down -v` deletes all volumes, including credentials. You'll need to run `claude auth login` again afterwards.
 
 ## Project Structure
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { buildServer } from "./api/server.js";
 import { createLogger } from "./utils/logger.js";
@@ -7,7 +8,31 @@ const log = createLogger("main");
 const port = parseInt(process.env.PORT ?? "6100", 10);
 const dataDir = path.resolve(process.env.DATA_DIR ?? "./data");
 
+function checkClaudeAuth(): void {
+  try {
+    const raw = execSync("claude auth status", { encoding: "utf-8", timeout: 5000 });
+    const status = JSON.parse(raw);
+    if (status.loggedIn) {
+      log.info({ authMethod: status.authMethod, subscriptionType: status.subscriptionType }, "Claude CLI authenticated");
+    } else {
+      log.warn("Claude CLI not authenticated — pipelines will fail");
+      log.warn("Fix: set ANTHROPIC_API_KEY in .env, or run: docker compose exec api claude auth login");
+    }
+  } catch {
+    if (process.env.ANTHROPIC_API_KEY) {
+      log.info("Claude auth: using ANTHROPIC_API_KEY");
+    } else if (process.env.ANTHROPIC_AUTH_TOKEN) {
+      log.info("Claude auth: using ANTHROPIC_AUTH_TOKEN");
+    } else {
+      log.warn("Claude CLI not found or not authenticated — pipelines will fail");
+      log.warn("Fix: set ANTHROPIC_API_KEY in .env, or run: docker compose exec api claude auth login");
+    }
+  }
+}
+
 async function main() {
+  checkClaudeAuth();
+
   const app = await buildServer(dataDir);
 
   await app.listen({ port, host: "0.0.0.0" });

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -5,8 +5,16 @@ services:
   api:
     volumes:
       # ── Claude CLI Credentials (Max subscription) ──────────
-      # Mount your local Claude CLI credentials into the container.
-      # Only needed if you DON'T set ANTHROPIC_API_KEY in .env.
+      # Only needed if you use Option 3 (CLI Login) from .env.example.
+      # Authenticate once inside the container:
+      #   docker compose exec api claude login
+      # Credentials persist in the volume across container rebuilds.
+      # The CLI refreshes expired tokens automatically.
+      #
+      # - claude-credentials:/root/.claude
+      #
+      # Alternative: Mount credential files directly (Linux only).
+      # On macOS, credentials are stored in Keychain — these files don't exist.
       # - ~/.claude.json:/root/.claude.json:ro
       # - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
     environment: {}
@@ -17,3 +25,7 @@ services:
     environment: {}
       # ── Custom API URL ─────────────────────────────────────
       # - NEXT_PUBLIC_API_URL=https://api.yourdomain.com
+
+# Uncomment if using the named volume above.
+# volumes:
+#   claude-credentials:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,26 +1,172 @@
 #!/bin/bash
-# FlowBoost — Initial data setup
-# Copies seed data to backend/data/ if it doesn't exist yet.
+# FlowBoost — Project setup
+# Creates .env, configures authentication, and seeds initial data.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$ROOT_DIR/.env"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+OVERRIDE_FILE="$ROOT_DIR/docker-compose.override.yml"
 DATA_DIR="$ROOT_DIR/backend/data"
 SEED_DIR="$ROOT_DIR/backend/data.seed"
 
+echo ""
+echo "  FlowBoost Setup"
+echo "  ==============="
+echo ""
+
+# ── Step 1: Create .env ────────────────────────────────────
+
+if [ ! -f "$ENV_FILE" ]; then
+  if [ ! -f "$ENV_EXAMPLE" ]; then
+    echo "Error: .env.example not found."
+    exit 1
+  fi
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+  echo "Created .env from .env.example"
+else
+  echo ".env already exists, keeping it."
+fi
+
+# ── Step 2: Authentication ─────────────────────────────────
+
+echo ""
+echo "  How do you want to authenticate with Claude?"
+echo ""
+echo "  1) API Key          — Anthropic Console key (pay-per-use)"
+echo "  2) OAuth Token      — Access token from Max/Pro subscription"
+echo "  3) CLI Login        — Log in inside the Docker container (recommended for Max/Pro)"
+echo "  4) Skip             — Already configured"
+echo ""
+printf "  Choose [1-4]: "
+read -r AUTH_CHOICE
+
+case "$AUTH_CHOICE" in
+  1)
+    echo ""
+    printf "  Paste your API key (sk-ant-...): "
+    read -r API_KEY
+    if [ -z "$API_KEY" ]; then
+      echo "  No key entered, skipping."
+    else
+      # Set ANTHROPIC_API_KEY in .env
+      if grep -q "^ANTHROPIC_API_KEY=" "$ENV_FILE"; then
+        sed -i.bak "s|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=$API_KEY|" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+      else
+        echo "ANTHROPIC_API_KEY=$API_KEY" >> "$ENV_FILE"
+      fi
+      echo "  Saved API key to .env"
+    fi
+    ;;
+  2)
+    echo ""
+    echo "  On Linux:  cat ~/.claude/.credentials.json | grep accessToken"
+    echo "  On macOS:  Open Keychain Access and search for 'claude'"
+    echo ""
+    printf "  Paste your OAuth token (sk-ant-oat01-...): "
+    read -r AUTH_TOKEN
+    if [ -z "$AUTH_TOKEN" ]; then
+      echo "  No token entered, skipping."
+    else
+      # Set ANTHROPIC_AUTH_TOKEN in .env
+      if grep -q "^# ANTHROPIC_AUTH_TOKEN=" "$ENV_FILE"; then
+        sed -i.bak "s|^# ANTHROPIC_AUTH_TOKEN=.*|ANTHROPIC_AUTH_TOKEN=$AUTH_TOKEN|" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+      elif grep -q "^ANTHROPIC_AUTH_TOKEN=" "$ENV_FILE"; then
+        sed -i.bak "s|^ANTHROPIC_AUTH_TOKEN=.*|ANTHROPIC_AUTH_TOKEN=$AUTH_TOKEN|" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+      else
+        echo "ANTHROPIC_AUTH_TOKEN=$AUTH_TOKEN" >> "$ENV_FILE"
+      fi
+      echo "  Saved OAuth token to .env"
+      echo ""
+      echo "  Note: This token expires after a few months."
+      echo "  When it does, update .env or switch to option 3 (CLI Login)."
+    fi
+    ;;
+  3)
+    echo ""
+    # Create docker-compose.override.yml with named volume
+    if [ -f "$OVERRIDE_FILE" ]; then
+      echo "  docker-compose.override.yml already exists."
+      echo "  Please add this manually if not already present:"
+      echo ""
+      echo "    services:"
+      echo "      api:"
+      echo "        volumes:"
+      echo "          - claude-credentials:/root/.claude"
+      echo "    volumes:"
+      echo "      claude-credentials:"
+    else
+      cat > "$OVERRIDE_FILE" << 'YAML'
+services:
+  api:
+    volumes:
+      - claude-credentials:/root/.claude
+
+volumes:
+  claude-credentials:
+YAML
+      echo "  Created docker-compose.override.yml with credential volume."
+    fi
+    echo ""
+    echo "  After starting the containers, run:"
+    echo "    docker compose exec api claude auth login"
+    echo ""
+    echo "  This opens a URL — sign in with your Claude account."
+    echo "  Credentials persist in the Docker volume across rebuilds."
+    ;;
+  4)
+    echo "  Skipped."
+    ;;
+  *)
+    echo "  Invalid choice, skipping authentication setup."
+    ;;
+esac
+
+# ── Step 3: Gemini API Key (optional) ──────────────────────
+
+echo ""
+printf "  Google Gemini API key for image generation? (optional, Enter to skip): "
+read -r GEMINI_KEY
+if [ -n "$GEMINI_KEY" ]; then
+  if grep -q "^GEMINI_API_KEY=" "$ENV_FILE"; then
+    sed -i.bak "s|^GEMINI_API_KEY=.*|GEMINI_API_KEY=$GEMINI_KEY|" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+  else
+    echo "GEMINI_API_KEY=$GEMINI_KEY" >> "$ENV_FILE"
+  fi
+  echo "  Saved Gemini key to .env"
+else
+  echo "  Skipped (hero image generation will be disabled)."
+fi
+
+# ── Step 4: Seed data ──────────────────────────────────────
+
+echo ""
 if [ -d "$DATA_DIR/customers" ]; then
-  echo "backend/data/ already exists, skipping seed."
-  echo "To reset: rm -rf backend/data && bash scripts/setup.sh"
-  exit 0
+  echo "  Seed data already exists, skipping."
+  echo "  To reset: rm -rf backend/data && bash scripts/setup.sh"
+else
+  if [ ! -d "$SEED_DIR" ]; then
+    echo "  Error: backend/data.seed/ not found."
+    exit 1
+  fi
+  mkdir -p "$DATA_DIR"
+  cp -r "$SEED_DIR/customers" "$DATA_DIR/customers"
+  echo "  Seed data copied to backend/data/"
 fi
 
-if [ ! -d "$SEED_DIR" ]; then
-  echo "Error: backend/data.seed/ not found."
-  exit 1
-fi
+# ── Done ───────────────────────────────────────────────────
 
-mkdir -p "$DATA_DIR"
-cp -r "$SEED_DIR/customers" "$DATA_DIR/customers"
-echo "Seed data copied to backend/data/"
-echo "Ready to start: docker compose up --build"
+echo ""
+echo "  Setup complete. Next steps:"
+echo ""
+echo "    docker compose up --build"
+echo ""
+if [ "$AUTH_CHOICE" = "3" ]; then
+  echo "    # Then authenticate in a second terminal:"
+  echo "    docker compose exec api claude auth login"
+  echo ""
+fi
+echo "    Open http://localhost:6101"
+echo ""


### PR DESCRIPTION
## Summary
- Interactive `setup.sh` wizard: asks for auth method (API key, OAuth token, CLI login), Gemini key, seeds data
- Auth check at server startup with clear error when credentials are missing
- Document all 3 auth options in README, `.env.example`, and override example
- Named Docker volume approach for Max/Pro subscribers (works on macOS + Linux)

## Context
On macOS, the Claude CLI stores OAuth credentials in the Keychain, not as files. Contributors with Max subscriptions couldn't mount `~/.claude/` into Docker because the files don't exist on disk. The named volume + `claude auth login` approach works on all operating systems.

## Test plan
- [ ] Run `bash scripts/setup.sh` with option 1 (API key) — verify key is saved to `.env`
- [ ] Run `bash scripts/setup.sh` with option 3 (CLI login) — verify `docker-compose.override.yml` is created
- [ ] Start server without credentials — verify warning in logs
- [ ] Start server with credentials — verify "authenticated" log message