### PR TITLE
feat(auth): CLI Login durch Keychain-Export und File-Mount ersetzen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,9 @@ ANTHROPIC_API_KEY=
 #   or extract it from macOS Keychain. Expires after a few months.
 # ANTHROPIC_AUTH_TOKEN=
 #
-# Option 3: CLI Login (Max subscription, recommended)
-#   Leave both empty. Set up a persistent volume and run `claude login`
-#   inside the container. The CLI handles token refresh automatically.
+# Option 3: CLI Credentials (Max subscription, recommended)
+#   Leave both empty. Mount your local CLI credentials into the container.
+#   Requires Claude Code CLI installed and logged in on the host.
 #   See docker-compose.override.example.yml for setup.
 
 # ── Image Generation (optional) ──────────────────────────────

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ FlowBoost uses the [Claude Agent SDK](https://docs.anthropic.com/en/docs/agents/
 ### Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
-- An [Anthropic API key](https://console.anthropic.com) or Claude Max subscription
+- An [Anthropic API key](https://console.anthropic.com) **or** [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and logged in (`claude login`)
 - Optional: [Google Gemini API key](https://aistudio.google.com/apikey) for image generation
 
 ### Quick Start
@@ -106,40 +106,51 @@ ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-...
 
 > **Note:** The access token expires after a few months. When it does, you need to paste a fresh one. For automatic refresh, use Option 3.
 
-### Option 3: CLI Login (Max subscription, recommended)
+### Option 3: CLI Credentials (Max subscription, recommended)
 
-Authenticate the CLI inside the container using a persistent Docker volume. The CLI stores both access and refresh tokens, so credentials renew automatically.
+Mount your local Claude Code CLI credentials into the container. Requires the CLI installed and logged in on the host.
 
 ```bash
-# 1. Copy the override template
+# 1. Make sure you're logged in
+claude auth status
+# Expected: "loggedIn": true
+```
+
+On **macOS**, the CLI stores credentials in the Keychain, not as files. Export them first:
+
+```bash
+security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json
+```
+
+On **Linux**, `~/.claude/.credentials.json` already exists after `claude login` — no export needed.
+
+```bash
+# 2. Copy the override template
 cp docker-compose.override.example.yml docker-compose.override.yml
 ```
 
-Uncomment the named volume in `docker-compose.override.yml`:
+Uncomment the volume mounts in `docker-compose.override.yml`:
 
 ```yaml
 services:
   api:
     volumes:
-      - claude-credentials:/root/.claude
-
-volumes:
-  claude-credentials:
+      - ~/.claude.json:/root/.claude.json:ro
+      - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
 ```
 
 ```bash
-# 2. Start services
+# 3. Start services
 docker compose up --build -d
 
-# 3. Authenticate once inside the container
-docker compose exec api claude login
+# 4. Verify authentication inside the container
+docker compose exec api claude auth status
+# Expected: "loggedIn": true, "authMethod": "oauth_token"
 ```
 
-Credentials persist in the Docker volume across container rebuilds. Leave `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` empty in `.env`.
+Leave `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` empty in `.env`.
 
-> **Why not mount `~/.claude/` from the host?** On macOS, the CLI stores credentials in the Keychain, not as files — there's nothing to mount. The named volume approach works on all operating systems.
->
-> **Heads up:** `docker compose down -v` deletes all volumes, including credentials. You'll need to run `claude auth login` again afterwards.
+> **Note:** OAuth tokens expire. If the container reports `loggedIn: false`, re-export your credentials (macOS) or re-run `claude login` (Linux) and recreate the container with `docker compose up -d --force-recreate api`.
 
 ## Project Structure
 

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -5,16 +5,13 @@ services:
   api:
     volumes:
       # ── Claude CLI Credentials (Max subscription) ──────────
-      # Only needed if you use Option 3 (CLI Login) from .env.example.
-      # Authenticate once inside the container:
-      #   docker compose exec api claude login
-      # Credentials persist in the volume across container rebuilds.
-      # The CLI refreshes expired tokens automatically.
+      # Only needed if you use Option 3 (CLI Credentials) from README.
+      # Requires Claude Code CLI installed and logged in on the host.
       #
-      # - claude-credentials:/root/.claude
+      # On macOS, export credentials from Keychain first:
+      #   security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json
+      # On Linux, the file already exists after `claude login`.
       #
-      # Alternative: Mount credential files directly (Linux only).
-      # On macOS, credentials are stored in Keychain — these files don't exist.
       # - ~/.claude.json:/root/.claude.json:ro
       # - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
     environment: {}
@@ -25,7 +22,3 @@ services:
     environment: {}
       # ── Custom API URL ─────────────────────────────────────
       # - NEXT_PUBLIC_API_URL=https://api.yourdomain.com
-
-# Uncomment if using the named volume above.
-# volumes:
-#   claude-credentials:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -86,35 +86,65 @@ case "$AUTH_CHOICE" in
     ;;
   3)
     echo ""
-    # Create docker-compose.override.yml with named volume
-    if [ -f "$OVERRIDE_FILE" ]; then
-      echo "  docker-compose.override.yml already exists."
-      echo "  Please add this manually if not already present:"
-      echo ""
-      echo "    services:"
-      echo "      api:"
-      echo "        volumes:"
-      echo "          - claude-credentials:/root/.claude"
-      echo "    volumes:"
-      echo "      claude-credentials:"
+    # Check if Claude CLI is installed and logged in
+    if ! command -v claude &> /dev/null; then
+      echo "  Error: Claude Code CLI is not installed."
+      echo "  Install it first: https://docs.anthropic.com/en/docs/claude-code"
+      echo "  Then run: claude login"
+      echo "  Skipping."
+    elif ! claude auth status 2>/dev/null | grep -q '"loggedIn": true'; then
+      echo "  Error: Claude CLI is not logged in."
+      echo "  Run: claude login"
+      echo "  Skipping."
     else
-      cat > "$OVERRIDE_FILE" << 'YAML'
+      # Export credentials from Keychain on macOS
+      CRED_FILE="$HOME/.claude/.credentials.json"
+      if [[ "$(uname)" == "Darwin" ]]; then
+        echo "  macOS detected — exporting credentials from Keychain..."
+        KEYCHAIN_USER=$(whoami)
+        if security find-generic-password -s "Claude Code-credentials" -a "$KEYCHAIN_USER" -w > "$CRED_FILE" 2>/dev/null; then
+          echo "  Credentials exported to ~/.claude/.credentials.json"
+        else
+          echo "  Error: Could not export credentials from Keychain."
+          echo "  Make sure you are logged in: claude login"
+          echo "  Skipping."
+          CRED_FILE=""
+        fi
+      else
+        # Linux: credentials file should already exist
+        if [ ! -f "$CRED_FILE" ]; then
+          echo "  Error: ~/.claude/.credentials.json not found."
+          echo "  Run: claude login"
+          echo "  Skipping."
+          CRED_FILE=""
+        else
+          echo "  Credentials file found at ~/.claude/.credentials.json"
+        fi
+      fi
+
+      if [ -n "$CRED_FILE" ]; then
+        # Create docker-compose.override.yml with volume mounts
+        if [ -f "$OVERRIDE_FILE" ]; then
+          echo "  docker-compose.override.yml already exists."
+          echo "  Please add these volume mounts manually if not already present:"
+          echo ""
+          echo "    services:"
+          echo "      api:"
+          echo "        volumes:"
+          echo "          - ~/.claude.json:/root/.claude.json:ro"
+          echo "          - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro"
+        else
+          cat > "$OVERRIDE_FILE" << 'YAML'
 services:
   api:
     volumes:
-      - claude-credentials:/root/.claude
-
-volumes:
-  claude-credentials:
+      - ~/.claude.json:/root/.claude.json:ro
+      - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
 YAML
-      echo "  Created docker-compose.override.yml with credential volume."
+          echo "  Created docker-compose.override.yml with credential mounts."
+        fi
+      fi
     fi
-    echo ""
-    echo "  After starting the containers, run:"
-    echo "    docker compose exec api claude auth login"
-    echo ""
-    echo "  This opens a URL — sign in with your Claude account."
-    echo "  Credentials persist in the Docker volume across rebuilds."
     ;;
   4)
     echo "  Skipped."
@@ -164,8 +194,8 @@ echo ""
 echo "    docker compose up --build"
 echo ""
 if [ "$AUTH_CHOICE" = "3" ]; then
-  echo "    # Then authenticate in a second terminal:"
-  echo "    docker compose exec api claude auth login"
+  echo "    # Verify auth inside the container:"
+  echo "    docker compose exec api claude auth status"
   echo ""
 fi
 echo "    Open http://localhost:6101"


### PR DESCRIPTION
## Zusammenfassung

Option 3 (Max Subscription Auth) nutzt jetzt lokale CLI-Credentials statt `claude login` im Container:

- **macOS**: Automatischer Keychain-Export (`security find-generic-password`) in `~/.claude/.credentials.json`
- **Linux**: Nutzt die vorhandene `~/.claude/.credentials.json` direkt
- **Setup-Script**: Prüft ob CLI installiert und eingeloggt ist, erstellt Override mit File-Mounts
- **Prerequisite**: Claude Code CLI muss auf dem Host installiert und eingeloggt sein

### Geänderte Dateien
- `README.md` -- Prerequisite ergänzt, Option 3 umgeschrieben
- `.env.example` -- Option 3 Beschreibung aktualisiert
- `docker-compose.override.example.yml` -- File-Mounts statt Named Volume
- `scripts/setup.sh` -- Option 3 mit Keychain-Export und Validierung

### Warum?
Die bisherige Option 3 (`docker compose exec api claude login`) erfordert einen separaten Login-Schritt im Container nach jedem Start. Der File-Mount-Ansatz ist nahtloser -- einmal auf dem Host einloggen, dann funktioniert es automatisch.