### PR TITLE
feat(deploy): Production Compose, Auto-Seed und Deployment-Docs

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -11,15 +11,17 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:22-alpine AS runner
+FROM node:22-alpine
 
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV PORT=6001
+ENV HOSTNAME=0.0.0.0
 
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
-EXPOSE 3000
+EXPOSE 6001
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -173,48 +173,9 @@ data/customers/{id}/projects/{id}/
 └── pipeline-runs/   # Agent execution logs
 ```
 
-## Authentication Details
+## Deployment
 
-<details>
-<summary>Option 1: API Key (pay-per-use)</summary>
-
-```bash
-# .env
-ANTHROPIC_API_KEY=sk-ant-...
-```
-</details>
-
-<details>
-<summary>Option 2: OAuth Token (Max subscription)</summary>
-
-On Linux: `cat ~/.claude/.credentials.json | grep accessToken`
-On macOS: Extract from Keychain Access
-
-```bash
-# .env
-ANTHROPIC_AUTH_TOKEN=sk-ant-oat01-...
-```
-
-Token expires after a few months.
-</details>
-
-<details>
-<summary>Option 3: CLI Credentials (Max, recommended)</summary>
-
-```bash
-claude auth status   # Must show loggedIn: true
-
-# macOS: export from Keychain first
-security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json
-
-# Create override file
-cp docker-compose.override.example.yml docker-compose.override.yml
-# Uncomment volume mounts in docker-compose.override.yml
-
-docker compose up --build -d
-docker compose exec api claude auth status   # Verify
-```
-</details>
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for production setup, authentication options (API Key, OAuth, CLI Credentials), hosting platform guides (Dokploy/Coolify), and data persistence.
 
 ## Contributing
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
 import { buildServer } from "./api/server.js";
+import { CustomerStore } from "./models/customer.js";
 import { createLogger } from "./utils/logger.js";
 
 const log = createLogger("main");
@@ -32,6 +33,21 @@ function checkClaudeAuth(): void {
 
 async function main() {
   checkClaudeAuth();
+
+  // Auto-seed default customer on first run (empty data volume)
+  const customerStore = new CustomerStore(dataDir);
+  if (customerStore.list().length === 0) {
+    const now = new Date().toISOString();
+    customerStore.create({
+      name: "FlowBoost User",
+      slug: "default",
+      plan: "pro" as const,
+      authors: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+    log.info("Created default customer (first run)");
+  }
 
   const app = await buildServer(dataDir);
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,51 @@
+# Production deployment — standalone compose file (does NOT extend docker-compose.yml)
+# Usage: docker compose -f docker-compose.production.yml up --build -d
+
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: ../Dockerfile.backend
+    ports:
+      - "${PORT:-6100}:${PORT:-6100}"
+    volumes:
+      - flowboost-data:/app/data
+      - claude-credentials:/root/.claude
+    env_file: .env
+    environment:
+      - DATA_DIR=/app/data
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:${FRONTEND_PORT:-6101}}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:${PORT:-6100}/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  dashboard:
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile.frontend
+      args:
+        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:${PORT:-6100}}
+    ports:
+      - "${FRONTEND_PORT:-6101}:6001"
+    env_file: .env
+    environment:
+      - PORT=6001
+      - HOSTNAME=0.0.0.0
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:${PORT:-6100}}
+    depends_on:
+      - api
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:6001"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  flowboost-data:
+  claude-credentials:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,123 @@
+# Deployment
+
+## Authentication
+
+The Claude Agent SDK spawns Claude Code CLI as a subprocess. The CLI picks up credentials from environment variables or its own credential store.
+
+```
+.env (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)
+  → docker-compose.yml (env_file: .env)
+    → Container process.env
+      → Agent SDK query() spawns CLI subprocess (inherits env)
+        → CLI authenticates with Anthropic API
+```
+
+### Local Development
+
+The setup wizard handles everything interactively:
+
+```bash
+bash scripts/setup.sh
+```
+
+It creates `.env`, asks for your auth method (API Key, OAuth Token, or CLI Credentials), handles the macOS Keychain export automatically, creates `docker-compose.override.yml` with volume mounts if needed, and seeds initial data.
+
+The three auth options the wizard offers:
+
+| Option | Best for | What `setup.sh` does |
+|--------|----------|---------------------|
+| **API Key** | Pay-per-use | Saves `ANTHROPIC_API_KEY` to `.env` |
+| **OAuth Token** | Max/Pro subscription | Saves `ANTHROPIC_AUTH_TOKEN` to `.env` |
+| **CLI Credentials** | Max/Pro (recommended) | Exports Keychain (macOS), creates `docker-compose.override.yml` with volume mounts |
+
+> **macOS detail:** The CLI stores credentials in the Keychain, not as files. The setup wizard runs `security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json` for you. On Linux, `~/.claude/.credentials.json` already exists after `claude login`.
+
+### Dokploy / Coolify (Remote)
+
+On hosted platforms, `setup.sh` is not available. Two options:
+
+- **API Key**: Set `ANTHROPIC_API_KEY` as environment variable in the platform UI — done.
+- **CLI Login**: Open the terminal in the Dokploy dashboard for the API service, run `claude login`, follow the URL to authorize. Credentials persist in the `claude-credentials` volume across rebuilds.
+
+## Production with Docker Compose
+
+```bash
+docker compose -f docker-compose.production.yml up --build -d
+```
+
+Standalone compose file (does not extend the dev compose). Uses a production-optimized frontend build (Next.js standalone output) and named volumes for persistent data.
+
+A default customer is created automatically on first start — `setup.sh` is not needed for production.
+
+### Environment Variables
+
+Set these in your `.env` or hosting platform:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes (or CLI login) | Anthropic API key for Claude Agent SDK |
+| `GEMINI_API_KEY` | No | Google Gemini key for image generation |
+| `PORT` | No | Backend port (default: 6100) |
+| `FRONTEND_PORT` | No | Dashboard port (default: 6101) |
+| `FRONTEND_URL` | No | Public dashboard URL for CORS (default: http://localhost:6101) |
+| `NEXT_PUBLIC_API_URL` | No | API URL for browser (default: http://localhost:6100) |
+
+### Plain Docker (no platform)
+
+```bash
+docker compose -f docker-compose.production.yml up --build -d
+```
+
+Dashboard at `http://localhost:6101`, API at `http://localhost:6100`. No extra proxy needed for local/testing use. For production with a custom domain, put a reverse proxy in front (Caddy, Nginx, or Traefik) with path-based routing as described below.
+
+## Hosting Platforms
+
+### Dokploy / Coolify
+
+1. Create a new project, select **Compose** type, connect your GitHub repo
+2. Set compose path to `docker-compose.production.yml`
+3. Set environment variables in the platform UI:
+
+   | Variable | Required | Value |
+   |----------|----------|-------|
+   | `ANTHROPIC_API_KEY` | Yes (or use CLI login) | Your Anthropic Console key |
+   | `GEMINI_API_KEY` | No | Google Gemini key for image generation |
+   | `NEXT_PUBLIC_API_URL` | Yes | `/backend` (see step 5 below) |
+
+4. Configure **two domain entries** on the same host:
+   - `yourdomain.com` → **dashboard** service, port `6001`
+   - `yourdomain.com/backend` → **api** service, port `6100`, **strip path enabled**
+
+   This routes the dashboard and API through a single domain. The browser calls `/backend/health` and the platform strips `/backend` before forwarding to the API.
+
+5. Set `NEXT_PUBLIC_API_URL=/backend` as environment variable — this tells the frontend to call the API via the `/backend` path on the same domain.
+
+6. Deploy
+
+7. **Authentication** — choose one:
+   - **API Key**: Set `ANTHROPIC_API_KEY` as env var — done, no further steps
+   - **CLI Login** (Max/Pro subscription): Open the terminal in the Dokploy dashboard for the API service, run `claude login`, follow the URL to authorize. Credentials persist in the `claude-credentials` volume across rebuilds.
+
+8. Open your dashboard URL — the onboarding wizard will guide you through creating your first project
+
+> **Note:** `setup.sh` is NOT needed for production — a default customer is created automatically on first start. The onboarding wizard handles project setup.
+>
+> **Warning:** `docker compose down -v` deletes all volumes including credentials and data.
+
+## Data Persistence
+
+All runtime data (projects, content, media) is stored in `backend/data/`. In production, this is a named Docker volume (`flowboost-data`).
+
+### Backup
+
+```bash
+docker compose cp api:/app/data ./backup
+```
+
+### Restore
+
+```bash
+docker compose cp ./backup/. api:/app/data
+```
+
+> **Warning:** `docker compose down -v` deletes all volumes, including your data and CLI credentials.

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -352,8 +352,12 @@ export function Sidebar() {
       </div>
 
       {/* Footer */}
-      <div className="border-t px-4 py-3 text-xs text-muted-foreground">
-        flowboost v0.3.0
+      <div className="border-t px-4 py-3 text-xs text-muted-foreground flex items-center gap-2">
+        <span className={cn(
+          "h-2 w-2 rounded-full",
+          process.env.NODE_ENV === "production" ? "bg-green-500" : "bg-amber-500"
+        )} />
+        flowboost v0.3.0{process.env.NODE_ENV !== "production" && " dev"}
       </div>
 
       <CreateProjectWizard


### PR DESCRIPTION
## Summary

- **docker-compose.production.yml** -- Standalone Production Compose mit Healthchecks, Named Volumes (data + credentials) und Build-Args
- **Dockerfile.frontend** -- Production-Stage mit Port 6001 und HOSTNAME=0.0.0.0 (statt Port 3000)
- **Auto-Seed** -- Default-Customer wird bei leerem Data-Volume automatisch erstellt (kein setup.sh in Production nötig)
- **Dev/Prod-Indikator** -- Sidebar-Footer zeigt grünen Dot (production) oder amber Dot + "dev" (development)
- **docs/DEPLOYMENT.md** -- Auth-Optionen (API Key, OAuth, CLI Credentials inkl. macOS Keychain), Dokploy/Coolify-Anleitung mit Domain-Setup (path-based routing), Data Persistence
- **README** -- Deployment-Sektion ausgelagert nach docs/DEPLOYMENT.md (wie ARCHITECTURE.md und AGENTS.md)

## Test Plan

- [x] Production Compose: beide Services healthy (`docker compose -f docker-compose.production.yml up --build -d`)
- [x] Dev Compose: funktioniert weiterhin (`docker compose up --build`)
- [x] Fresh Deploy mit leerem Volume: Default-Customer wird erstellt, Onboarding funktioniert
- [x] Healthchecks nutzen 127.0.0.1 statt localhost (IPv6-Problem in Alpine)