### PR TITLE
feat(media): zentrale Media Library mit Tags, Usage-Tracking und Picker

### DIFF
--- a/backend/src/api/routes/media.ts
+++ b/backend/src/api/routes/media.ts
@@ -1,25 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../../utils/logger.js";
 import { MediaService } from "../../services/media.js";
-import type { MediaType } from "../../models/types.js";
+import type { MediaType, MediaSource, MediaFilter } from "../../models/types.js";
 
 const log = createLogger("api:media");
 
 export async function mediaRoutes(app: FastifyInstance) {
+  // GET /media/tags — all tags with count
+  app.get<{
+    Params: { customerId: string; projectId: string };
+  }>("/tags", async (request) => {
+    const { customerId, projectId } = request.params;
+    const store = app.ctx.mediaFor(customerId, projectId);
+
+    const assets = store.list();
+    const tagMap = new Map<string, number>();
+    for (const asset of assets) {
+      for (const tag of asset.tags ?? []) {
+        tagMap.set(tag, (tagMap.get(tag) ?? 0) + 1);
+      }
+    }
+
+    const tags = Array.from(tagMap.entries())
+      .map(([name, count]) => ({ tag: name, count }))
+      .sort((a, b) => b.count - a.count);
+
+    return { tags };
+  });
+
   // GET /media — list assets with filters
   app.get<{
     Params: { customerId: string; projectId: string };
-    Querystring: { type?: MediaType; source?: string };
+    Querystring: {
+      type?: MediaType;
+      source?: MediaSource;
+      tags?: string;
+      search?: string;
+      unused?: string;
+      page?: string;
+      limit?: string;
+    };
   }>("/", async (request) => {
     const { customerId, projectId } = request.params;
-    const { type, source } = request.query;
+    const { type, source, tags, search, unused, page, limit } = request.query;
     const store = app.ctx.mediaFor(customerId, projectId);
 
-    let assets = store.list();
-    if (type) assets = assets.filter((a) => a.type === type);
-    if (source) assets = assets.filter((a) => a.source === source);
+    const filter: MediaFilter = {
+      type,
+      source,
+      tags: tags ? tags.split(",").map((t) => t.trim()) : undefined,
+      search,
+      unused: unused === "true" ? true : unused === "false" ? false : undefined,
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+    };
 
-    return { total: assets.length, assets };
+    let assets = store.list();
+
+    if (filter.type) {
+      assets = assets.filter((a) => a.type === filter.type);
+    }
+    if (filter.source) {
+      assets = assets.filter((a) => a.source === filter.source);
+    }
+    if (filter.tags && filter.tags.length > 0) {
+      assets = assets.filter((a) =>
+        filter.tags!.every((t) => (a.tags ?? []).includes(t))
+      );
+    }
+    if (filter.search) {
+      const q = filter.search.toLowerCase();
+      assets = assets.filter(
+        (a) =>
+          a.fileName.toLowerCase().includes(q) ||
+          (a.title ?? "").toLowerCase().includes(q) ||
+          (a.description ?? "").toLowerCase().includes(q) ||
+          (a.altText ?? "").toLowerCase().includes(q)
+      );
+    }
+    if (filter.unused === true) {
+      assets = assets.filter((a) => (a.usedBy ?? []).length === 0);
+    } else if (filter.unused === false) {
+      assets = assets.filter((a) => (a.usedBy ?? []).length > 0);
+    }
+
+    const total = assets.length;
+    const pageNum = filter.page ?? 1;
+    const pageSize = filter.limit ?? 50;
+    const offset = (pageNum - 1) * pageSize;
+    const paged = assets.slice(offset, offset + pageSize);
+
+    return { total, page: pageNum, limit: pageSize, totalPages: Math.ceil(total / pageSize), assets: paged };
   });
 
   // POST /media/upload — multipart file upload
@@ -37,69 +110,347 @@ export async function mediaRoutes(app: FastifyInstance) {
     const store = app.ctx.mediaFor(customerId, projectId);
     const service = new MediaService(store);
 
+    const fields = data.fields as Record<string, { value?: string } | undefined>;
+    const title = fields.title?.value;
+    const description = fields.description?.value;
+    const altText = fields.altText?.value;
+    let tags: string[] | undefined;
+    if (fields.tags?.value) {
+      try {
+        tags = JSON.parse(fields.tags.value);
+      } catch {
+        return reply.status(400).send({ error: "tags must be a valid JSON array" });
+      }
+    }
+
     const result = await service.ingest({
       customerId,
       projectId,
       fileName: data.filename,
       mimeType: data.mimetype,
       buffer,
-      altText: (data.fields.altText as { value?: string })?.value,
+      altText,
+      title,
+      description,
+      tags,
     });
 
     log.info({ assetId: result.asset.id, fileName: data.filename }, "file uploaded");
-    return result;
+    return { asset: store.get(result.asset.id) ?? result.asset, thumbnailGenerated: result.thumbnailGenerated };
   });
 
-  // POST /media/generate — AI generation request (placeholder)
+  // POST /media/bulk/upload — multi-file upload
+  app.post<{
+    Params: { customerId: string; projectId: string };
+  }>("/bulk/upload", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const service = new MediaService(store);
+
+    const results: Array<{ fileName: string; asset?: unknown; error?: string }> = [];
+    let succeeded = 0;
+    let failed = 0;
+    let metadata: { tags?: string[]; title_prefix?: string; description?: string } = {};
+
+    const parts = request.parts();
+    for await (const part of parts) {
+      if (part.type === "field") {
+        if (part.fieldname === "metadata" && typeof part.value === "string") {
+          try {
+            metadata = JSON.parse(part.value);
+          } catch {
+            return reply.status(400).send({ error: "metadata must be valid JSON" });
+          }
+        }
+        continue;
+      }
+
+      try {
+        const buffer = await part.toBuffer();
+        const result = await service.ingest({
+          customerId,
+          projectId,
+          fileName: part.filename,
+          mimeType: part.mimetype,
+          buffer,
+          tags: metadata.tags,
+          title: metadata.title_prefix ? `${metadata.title_prefix} ${part.filename}` : undefined,
+          description: metadata.description,
+        });
+
+        results.push({ fileName: part.filename, asset: store.get(result.asset.id) ?? result.asset });
+        succeeded++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        results.push({ fileName: part.filename, error: message });
+        failed++;
+        log.warn({ err, fileName: part.filename }, "bulk upload: file failed");
+      }
+    }
+
+    log.info({ total: succeeded + failed, succeeded, failed }, "bulk upload completed");
+    return { total: succeeded + failed, succeeded, failed, results };
+  });
+
+  // POST /media/bulk/update — bulk tag update
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: { assetIds: string[]; addTags?: string[]; removeTags?: string[] };
+  }>("/bulk/update", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const { assetIds, addTags, removeTags } = request.body;
+
+    if (!assetIds || !Array.isArray(assetIds) || assetIds.length === 0) {
+      return reply.status(400).send({ error: "assetIds must be a non-empty array" });
+    }
+
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const now = new Date().toISOString();
+    const updated: string[] = [];
+    const notFound: string[] = [];
+
+    for (const assetId of assetIds) {
+      const asset = store.get(assetId);
+      if (!asset) { notFound.push(assetId); continue; }
+
+      let tags = [...(asset.tags ?? [])];
+      if (addTags) {
+        for (const tag of addTags) {
+          if (!tags.includes(tag)) tags.push(tag);
+        }
+      }
+      if (removeTags) {
+        tags = tags.filter((t) => !removeTags.includes(t));
+      }
+
+      store.update(assetId, { tags, updatedAt: now } as Partial<typeof asset>);
+      updated.push(assetId);
+    }
+
+    log.info({ updated: updated.length, notFound: notFound.length }, "bulk tag update completed");
+    return { updated, notFound };
+  });
+
+  // POST /media/bulk/delete — bulk delete
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: { assetIds: string[]; force?: boolean };
+  }>("/bulk/delete", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const { assetIds, force } = request.body;
+
+    if (!assetIds || !Array.isArray(assetIds) || assetIds.length === 0) {
+      return reply.status(400).send({ error: "assetIds must be a non-empty array" });
+    }
+
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const deleted: string[] = [];
+    const notFound: string[] = [];
+    const inUse: string[] = [];
+
+    for (const assetId of assetIds) {
+      const asset = store.get(assetId);
+      if (!asset) { notFound.push(assetId); continue; }
+      if (!force && (asset.usedBy ?? []).length > 0) { inUse.push(assetId); continue; }
+      store.delete(assetId);
+      deleted.push(assetId);
+    }
+
+    log.info({ deleted: deleted.length, notFound: notFound.length, inUse: inUse.length }, "bulk delete completed");
+    return { deleted, notFound, inUse };
+  });
+
+  // POST /media/generate — AI image generation
   app.post<{
     Params: { customerId: string; projectId: string };
     Body: {
-      type: MediaType;
       prompt: string;
-      model?: string;
+      aspectRatio?: string;
+      title?: string;
+      tags?: string[];
+      linkToContent?: { contentId: string; role: string };
     };
   }>("/generate", async (request, reply) => {
-    const { customerId: _customerId, projectId: _projectId } = request.params;
-    const body = request.body as { type: MediaType; prompt: string; model?: string };
+    const { customerId, projectId } = request.params;
+    const { prompt, aspectRatio, title, tags, linkToContent } = request.body;
 
-    // Phase 2/3: AI Service Registry will handle this
-    log.info({ type: body.type, model: body.model }, "media generation requested (not yet implemented)");
-    return reply.status(501).send({
-      error: "AI media generation not yet implemented",
-      hint: "Phase 2 (video) / Phase 3 (audio) — coming soon",
-      requested: { type: body.type, prompt: body.prompt, model: body.model },
-    });
+    if (!prompt) {
+      return reply.status(400).send({ error: "prompt is required" });
+    }
+
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const service = new MediaService(store);
+
+    try {
+      const result = await service.generate({ customerId, projectId, prompt, aspectRatio, title, tags });
+
+      if (linkToContent) {
+        const asset = store.get(result.asset.id);
+        if (asset) {
+          const usedBy = [...(asset.usedBy ?? [])];
+          usedBy.push({
+            contentId: linkToContent.contentId,
+            role: linkToContent.role as "hero" | "inline" | "thumbnail" | "attachment" | "social_media",
+            addedAt: new Date().toISOString(),
+          });
+          store.update(result.asset.id, { usedBy, updatedAt: new Date().toISOString() } as Partial<typeof asset>);
+        }
+      }
+
+      log.info({ assetId: result.asset.id, prompt }, "media generated");
+      return { asset: store.get(result.asset.id) ?? result.asset };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Generation failed";
+      log.error({ err, prompt }, "media generation failed");
+      return reply.status(500).send({ error: message });
+    }
   });
 
-  // GET /media/:assetId — get asset metadata
+  // GET /media/:assetId — asset metadata
   app.get<{
     Params: { customerId: string; projectId: string; assetId: string };
   }>("/:assetId", async (request, reply) => {
     const { customerId, projectId, assetId } = request.params;
     const store = app.ctx.mediaFor(customerId, projectId);
     const asset = store.get(assetId);
-
-    if (!asset) {
-      return reply.status(404).send({ error: "Media asset not found" });
-    }
-
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
     return asset;
   });
 
-  // DELETE /media/:assetId
-  app.delete<{
+  // PATCH /media/:assetId — metadata update
+  app.patch<{
     Params: { customerId: string; projectId: string; assetId: string };
+    Body: { title?: string; description?: string; tags?: string[]; altText?: string };
   }>("/:assetId", async (request, reply) => {
     const { customerId, projectId, assetId } = request.params;
+    const { title, description, tags, altText } = request.body;
+    const store = app.ctx.mediaFor(customerId, projectId);
+
+    const asset = store.get(assetId);
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+
+    const updates: Record<string, unknown> = {};
+    if (title !== undefined) updates.title = title;
+    if (description !== undefined) updates.description = description;
+    if (tags !== undefined) updates.tags = tags;
+    if (altText !== undefined) updates.altText = altText;
+    updates.updatedAt = new Date().toISOString();
+
+    const updated = store.update(assetId, updates);
+    log.info({ assetId }, "media asset metadata updated");
+    return updated;
+  });
+
+  // DELETE /media/:assetId — with force option
+  app.delete<{
+    Params: { customerId: string; projectId: string; assetId: string };
+    Querystring: { force?: string };
+  }>("/:assetId", async (request, reply) => {
+    const { customerId, projectId, assetId } = request.params;
+    const { force } = request.query;
     const store = app.ctx.mediaFor(customerId, projectId);
     const asset = store.get(assetId);
 
-    if (!asset) {
-      return reply.status(404).send({ error: "Media asset not found" });
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+
+    if (force !== "true" && (asset.usedBy ?? []).length > 0) {
+      return reply.status(409).send({
+        error: "Asset is in use",
+        usedBy: asset.usedBy,
+        hint: "Use ?force=true to delete anyway",
+      });
     }
 
     store.delete(assetId);
     log.info({ assetId }, "media asset deleted");
     return { message: "Asset deleted", assetId };
+  });
+
+  // GET /media/:assetId/file — original file stream
+  app.get<{
+    Params: { customerId: string; projectId: string; assetId: string };
+  }>("/:assetId/file", async (request, reply) => {
+    const { customerId, projectId, assetId } = request.params;
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const asset = store.get(assetId);
+
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+
+    const originalDir = store.getOriginalDir(assetId);
+    const filePath = path.join(originalDir, path.basename(asset.localPath));
+
+    if (!fs.existsSync(filePath)) return reply.status(404).send({ error: "Original file not found on disk" });
+
+    reply.header("Content-Type", asset.mimeType);
+    reply.header("Content-Disposition", `inline; filename="${asset.fileName}"`);
+    return reply.send(fs.createReadStream(filePath));
+  });
+
+  // GET /media/:assetId/thumbnail — thumbnail stream
+  app.get<{
+    Params: { customerId: string; projectId: string; assetId: string };
+  }>("/:assetId/thumbnail", async (request, reply) => {
+    const { customerId, projectId, assetId } = request.params;
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const asset = store.get(assetId);
+
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+    if (!asset.thumbnailPath) return reply.status(404).send({ error: "No thumbnail available" });
+
+    const thumbPath = path.join(store.entityDir(assetId), asset.thumbnailPath);
+    if (!fs.existsSync(thumbPath)) return reply.status(404).send({ error: "Thumbnail file not found on disk" });
+
+    reply.header("Content-Type", "image/webp");
+    reply.header("Content-Disposition", `inline; filename="thumb-${assetId}.webp"`);
+    return reply.send(fs.createReadStream(thumbPath));
+  });
+
+  // POST /media/:assetId/usage — add usage reference
+  app.post<{
+    Params: { customerId: string; projectId: string; assetId: string };
+    Body: { contentId: string; role: string };
+  }>("/:assetId/usage", async (request, reply) => {
+    const { customerId, projectId, assetId } = request.params;
+    const { contentId, role } = request.body;
+
+    if (!contentId || !role) return reply.status(400).send({ error: "contentId and role are required" });
+
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const asset = store.get(assetId);
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+
+    const usedBy = [...(asset.usedBy ?? [])];
+    if (usedBy.some((u) => u.contentId === contentId && u.role === role)) {
+      return reply.status(409).send({ error: "Usage reference already exists" });
+    }
+
+    usedBy.push({
+      contentId,
+      role: role as "hero" | "inline" | "thumbnail" | "attachment" | "social_media",
+      addedAt: new Date().toISOString(),
+    });
+
+    store.update(assetId, { usedBy, updatedAt: new Date().toISOString() } as Partial<typeof asset>);
+    log.info({ assetId, contentId, role }, "usage added");
+    return { message: "Usage added", assetId, contentId, role };
+  });
+
+  // DELETE /media/:assetId/usage/:contentId — remove usage reference
+  app.delete<{
+    Params: { customerId: string; projectId: string; assetId: string; contentId: string };
+  }>("/:assetId/usage/:contentId", async (request, reply) => {
+    const { customerId, projectId, assetId, contentId } = request.params;
+    const store = app.ctx.mediaFor(customerId, projectId);
+    const asset = store.get(assetId);
+    if (!asset) return reply.status(404).send({ error: "Media asset not found" });
+
+    const usedBy = (asset.usedBy ?? []).filter((u) => u.contentId !== contentId);
+    if (usedBy.length === (asset.usedBy ?? []).length) {
+      return reply.status(404).send({ error: "Usage reference not found" });
+    }
+
+    store.update(assetId, { usedBy, updatedAt: new Date().toISOString() } as Partial<typeof asset>);
+    log.info({ assetId, contentId }, "usage removed");
+    return { message: "Usage removed", assetId, contentId };
   });
 }

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -435,6 +435,11 @@ export interface MediaAsset {
   height?: number;
   altText?: string;
 
+  title?: string;
+  description?: string;
+  tags: string[];
+  usedBy: MediaUsageRef[];
+
   durationSeconds?: number;
   resolution?: string;
   thumbnailPath?: string;
@@ -445,6 +450,22 @@ export interface MediaAsset {
 
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MediaUsageRef {
+  contentId: string;
+  role: "hero" | "inline" | "thumbnail" | "attachment" | "social_media";
+  addedAt: string;
+}
+
+export interface MediaFilter {
+  type?: MediaType;
+  source?: MediaSource;
+  tags?: string[];
+  search?: string;
+  unused?: boolean;
+  page?: number;
+  limit?: number;
 }
 
 export interface MediaAssetRef {

--- a/backend/src/services/media.ts
+++ b/backend/src/services/media.ts
@@ -32,6 +32,9 @@ interface IngestOptions {
   buffer: Buffer;
   source?: MediaSource;
   altText?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
   generationPrompt?: string;
   generationModel?: string;
   generationCostUsd?: number;
@@ -60,6 +63,10 @@ export class MediaService {
       fileSize: opts.buffer.length,
       localPath: "", // set after save
       altText: opts.altText,
+      title: opts.title,
+      description: opts.description,
+      tags: opts.tags ?? [],
+      usedBy: [],
       generationPrompt: opts.generationPrompt,
       generationModel: opts.generationModel,
       generationCostUsd: opts.generationCostUsd,
@@ -132,5 +139,33 @@ export class MediaService {
       .resize(maxWidth, undefined, { withoutEnlargement: true })
       .webp({ quality: 80 })
       .toFile(outputPath);
+  }
+
+  async generate(opts: {
+    customerId: string;
+    projectId: string;
+    prompt: string;
+    aspectRatio?: string;
+    title?: string;
+    tags?: string[];
+  }): Promise<IngestResult> {
+    const { generateImageBuffer } = await import("./imagen.js");
+    const buffer = await generateImageBuffer(opts.prompt, {
+      aspectRatio: opts.aspectRatio as "16:9" | "1:1" | "9:16" | "4:3" | "3:4" | undefined,
+    });
+
+    return this.ingest({
+      customerId: opts.customerId,
+      projectId: opts.projectId,
+      fileName: `generated-${Date.now()}.png`,
+      mimeType: "image/png",
+      buffer,
+      source: "generated",
+      title: opts.title ?? `Generated: ${opts.prompt.slice(0, 60)}`,
+      tags: opts.tags ?? [],
+      generationPrompt: opts.prompt,
+      generationModel: process.env.IMAGEN_MODEL ?? "imagen-4.0-fast-generate-001",
+      generationCostUsd: 0.02,
+    });
   }
 }

--- a/frontend/src/app/media/page.tsx
+++ b/frontend/src/app/media/page.tsx
@@ -1,0 +1,734 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useProject } from "@/lib/project-context";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  Upload,
+  Trash2,
+  Tag,
+  Search,
+  ImageIcon,
+  Film,
+  FileText,
+  Music,
+  X,
+  Loader2,
+  Check,
+  Plus,
+} from "lucide-react";
+import type { MediaAsset, MediaType, MediaSource } from "@/lib/types";
+import * as api from "@/lib/api";
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function typeIcon(type: MediaType, className = "h-8 w-8 text-muted-foreground") {
+  switch (type) {
+    case "image":
+      return <ImageIcon className={className} />;
+    case "video":
+      return <Film className={className} />;
+    case "audio":
+      return <Music className={className} />;
+    case "document":
+      return <FileText className={className} />;
+    default:
+      return <FileText className={className} />;
+  }
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ── Page ──────────────────────────────────────────────────────────
+
+export default function MediaPage() {
+  const { customerId, projectId, loading: projectLoading } = useProject();
+
+  // Data
+  const [assets, setAssets] = useState<MediaAsset[]>([]);
+  const [allTags, setAllTags] = useState<{ tag: string; count: number }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [search, setSearch] = useState("");
+  const [filterType, setFilterType] = useState<string>("all");
+  const [filterSource, setFilterSource] = useState<string>("all");
+  const [filterTag, setFilterTag] = useState<string>("all");
+
+  // Selection
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Detail panel
+  const [detailAsset, setDetailAsset] = useState<MediaAsset | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editAltText, setEditAltText] = useState("");
+  const [editTags, setEditTags] = useState<string[]>([]);
+  const [newTag, setNewTag] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [usageTitles, setUsageTitles] = useState<Record<string, string>>({});
+
+  // Upload
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Bulk-Tag Dialog
+  const [bulkTagOpen, setBulkTagOpen] = useState(false);
+  const [bulkTagValue, setBulkTagValue] = useState("");
+
+  // ── Data loading ───────────────────────────────────────────────
+
+  const loadData = useCallback(async () => {
+    if (!customerId || !projectId) return;
+    try {
+      const [mediaResult, tagsResult] = await Promise.all([
+        api.getMedia(customerId, projectId, {
+          type: filterType !== "all" ? filterType : undefined,
+          source: filterSource !== "all" ? filterSource : undefined,
+          tags: filterTag !== "all" ? filterTag : undefined,
+          search: search || undefined,
+        }),
+        api.getMediaTags(customerId, projectId),
+      ]);
+      setAssets(mediaResult.assets);
+      setAllTags(tagsResult.tags);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Medien konnten nicht geladen werden");
+    }
+  }, [customerId, projectId, filterType, filterSource, filterTag, search]);
+
+  useEffect(() => {
+    if (!customerId || !projectId) return;
+    setLoading(true);
+    setError(null);
+    loadData().finally(() => setLoading(false));
+  }, [customerId, projectId, loadData]);
+
+  // ── Upload handler ─────────────────────────────────────────────
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0 || !customerId || !projectId) return;
+    setUploading(true);
+    try {
+      const uploadPromises = Array.from(files).map((file) =>
+        api.uploadMedia(customerId, projectId, file),
+      );
+      const results = await Promise.all(uploadPromises);
+      const newAssets = results.map((r) => r.asset);
+      setAssets((prev) => [...newAssets, ...prev]);
+    } catch {
+      // Upload fehlgeschlagen
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  // ── Selection handlers ─────────────────────────────────────────
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  // ── Detail panel ───────────────────────────────────────────────
+
+  const openDetail = async (asset: MediaAsset) => {
+    setDetailAsset(asset);
+    setEditTitle(asset.title ?? "");
+    setEditDescription(asset.description ?? "");
+    setEditAltText(asset.altText ?? "");
+    // Resolve content titles for usedBy references
+    if (asset.usedBy.length > 0 && customerId && projectId) {
+      const titles: Record<string, string> = {};
+      await Promise.all(
+        asset.usedBy.map(async (ref) => {
+          if (usageTitles[ref.contentId]) {
+            titles[ref.contentId] = usageTitles[ref.contentId];
+            return;
+          }
+          try {
+            const item = await api.getContentItem(customerId, projectId, ref.contentId);
+            titles[ref.contentId] = item.title;
+          } catch {
+            titles[ref.contentId] = ref.contentId.slice(0, 8) + "...";
+          }
+        }),
+      );
+      setUsageTitles((prev) => ({ ...prev, ...titles }));
+    }
+    setEditTags([...asset.tags]);
+    setNewTag("");
+    setDetailOpen(true);
+  };
+
+  const handleSaveDetail = async () => {
+    if (!detailAsset || !customerId || !projectId) return;
+    setSaving(true);
+    try {
+      const updated = await api.updateMediaAsset(customerId, projectId, detailAsset.id, {
+        title: editTitle || undefined,
+        description: editDescription || undefined,
+        altText: editAltText || undefined,
+        tags: editTags,
+      });
+      setDetailAsset(updated);
+      setAssets((prev) => prev.map((a) => (a.id === updated.id ? updated : a)));
+    } catch {
+      // Speichern fehlgeschlagen
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteDetail = async () => {
+    if (!detailAsset || !customerId || !projectId) return;
+    const hasUsages = detailAsset.usedBy.length > 0;
+    if (hasUsages && !confirm("Dieses Asset wird von Content-Items referenziert. Trotzdem löschen?")) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await api.deleteMediaAsset(customerId, projectId, detailAsset.id, hasUsages);
+      setAssets((prev) => prev.filter((a) => a.id !== detailAsset.id));
+      setDetailOpen(false);
+      setDetailAsset(null);
+    } catch {
+      // Löschen fehlgeschlagen
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const addTag = () => {
+    const tag = newTag.trim().toLowerCase();
+    if (tag && !editTags.includes(tag)) {
+      setEditTags((prev) => [...prev, tag]);
+    }
+    setNewTag("");
+  };
+
+  const removeTag = (tag: string) => {
+    setEditTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  // ── Bulk actions ───────────────────────────────────────────────
+
+  const handleBulkDelete = async () => {
+    if (selectedIds.size === 0 || !customerId || !projectId) return;
+    if (!confirm(`${selectedIds.size} Asset(s) wirklich löschen?`)) return;
+    try {
+      await api.bulkDeleteMedia(customerId, projectId, Array.from(selectedIds));
+      setAssets((prev) => prev.filter((a) => !selectedIds.has(a.id)));
+      clearSelection();
+    } catch {
+      // Bulk-Delete fehlgeschlagen
+    }
+  };
+
+  const handleBulkTag = async () => {
+    const tag = bulkTagValue.trim().toLowerCase();
+    if (!tag || selectedIds.size === 0 || !customerId || !projectId) return;
+    try {
+      const result = await api.bulkUpdateMedia(customerId, projectId, {
+        assetIds: Array.from(selectedIds),
+        addTags: [tag],
+      });
+      setAssets((prev) =>
+        prev.map((a) => {
+          if (result.updated.includes(a.id)) {
+            const tags = [...(a.tags ?? [])];
+            if (!tags.includes(tag)) tags.push(tag);
+            return { ...a, tags };
+          }
+          return a;
+        }),
+      );
+      setBulkTagOpen(false);
+      setBulkTagValue("");
+      clearSelection();
+    } catch {
+      // Bulk-Tag fehlgeschlagen
+    }
+  };
+
+  // ── Loading / Error ────────────────────────────────────────────
+
+  if (projectLoading || loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8">
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+          <p className="text-xs text-muted-foreground mt-1">Stelle sicher, dass das Backend auf Port 6100 läuft</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="p-8 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Media Library</h1>
+          <p className="text-muted-foreground text-sm">
+            {assets.length} Asset{assets.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            accept="image/*,video/*,audio/*,.pdf,.doc,.docx"
+            onChange={handleUpload}
+          />
+          <Button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+          >
+            {uploading ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Upload className="h-4 w-4 mr-2" />
+            )}
+            Upload
+          </Button>
+        </div>
+      </div>
+
+      {/* Filter Bar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[200px] max-w-sm">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Suchen..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8 h-9"
+          />
+        </div>
+        <Select value={filterType} onValueChange={setFilterType}>
+          <SelectTrigger className="w-36 h-9">
+            <SelectValue placeholder="Typ" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Alle Typen</SelectItem>
+            <SelectItem value="image">Bilder</SelectItem>
+            <SelectItem value="video">Videos</SelectItem>
+            <SelectItem value="audio">Audio</SelectItem>
+            <SelectItem value="document">Dokumente</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={filterSource} onValueChange={setFilterSource}>
+          <SelectTrigger className="w-36 h-9">
+            <SelectValue placeholder="Quelle" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Alle Quellen</SelectItem>
+            <SelectItem value="uploaded">Hochgeladen</SelectItem>
+            <SelectItem value="generated">Generiert</SelectItem>
+            <SelectItem value="extracted">Extrahiert</SelectItem>
+          </SelectContent>
+        </Select>
+        {allTags.length > 0 && (
+          <Select value={filterTag} onValueChange={setFilterTag}>
+            <SelectTrigger className="w-40 h-9">
+              <SelectValue placeholder="Tag" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Tags</SelectItem>
+              {allTags.map((t) => (
+                <SelectItem key={t.tag} value={t.tag}>
+                  {t.tag} ({t.count})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      {/* Asset Grid */}
+      {assets.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-md border border-dashed p-12 text-center">
+          <ImageIcon className="mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">Keine Medien vorhanden</p>
+          <p className="text-xs text-muted-foreground mt-1">Lade Dateien hoch oder generiere Bilder mit AI</p>
+          <Button className="mt-4" onClick={() => fileInputRef.current?.click()}>
+            <Upload className="mr-2 h-4 w-4" />
+            Erste Datei hochladen
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+          {assets.map((asset) => {
+            const isSelected = selectedIds.has(asset.id);
+            return (
+              <div
+                key={asset.id}
+                className="group relative rounded-lg border overflow-hidden bg-card hover:border-primary/30 transition-colors"
+              >
+                {/* Checkbox Overlay */}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelection(asset.id);
+                  }}
+                  className={`absolute top-2 left-2 z-10 h-5 w-5 rounded border flex items-center justify-center transition-all ${
+                    isSelected
+                      ? "bg-primary border-primary text-primary-foreground"
+                      : "bg-background/80 border-muted-foreground/30 opacity-0 group-hover:opacity-100"
+                  }`}
+                >
+                  {isSelected && <Check className="h-3 w-3" />}
+                </button>
+
+                {/* Thumbnail */}
+                <button
+                  type="button"
+                  onClick={() => openDetail(asset)}
+                  className="block w-full aspect-video focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {asset.type === "image" ? (
+                    <img
+                      src={api.getMediaThumbnailUrl(customerId, projectId, asset.id)}
+                      alt={asset.altText ?? asset.fileName}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      onError={(e) => {
+                        const img = e.currentTarget;
+                        if (!img.dataset.fallback) {
+                          img.dataset.fallback = "1";
+                          img.src = api.getMediaFileUrl(customerId, projectId, asset.id);
+                        }
+                      }}
+                    />
+                  ) : (
+                    <div className="w-full h-full flex flex-col items-center justify-center bg-muted/50 gap-1">
+                      {typeIcon(asset.type)}
+                    </div>
+                  )}
+                </button>
+
+                {/* Info */}
+                <div className="px-2.5 py-2">
+                  <p className="text-xs font-medium truncate">
+                    {asset.title ?? asset.fileName}
+                  </p>
+                  {asset.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {asset.tags.slice(0, 3).map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="text-[10px] px-1.5 py-0 h-4"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                      {asset.tags.length > 3 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          +{asset.tags.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* Source Badge */}
+                {asset.source === "generated" && (
+                  <Badge
+                    variant="secondary"
+                    className="absolute top-2 right-2 text-[9px] px-1 py-0 h-4"
+                  >
+                    AI
+                  </Badge>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Bulk Actions Bar */}
+      {selectedIds.size > 0 && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg border bg-background shadow-lg px-4 py-3">
+          <span className="text-sm font-medium">
+            {selectedIds.size} ausgewählt
+          </span>
+          <div className="h-4 w-px bg-border" />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setBulkTagOpen(true)}
+          >
+            <Tag className="h-4 w-4 mr-1.5" />
+            Tag
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={handleBulkDelete}
+          >
+            <Trash2 className="h-4 w-4 mr-1.5" />
+            Löschen
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={clearSelection}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Bulk Tag Mini-Dialog */}
+      {bulkTagOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-background rounded-lg border shadow-lg p-6 w-80 space-y-4">
+            <h3 className="text-sm font-semibold">Tag hinzufügen</h3>
+            <Input
+              placeholder="Tag-Name..."
+              value={bulkTagValue}
+              onChange={(e) => setBulkTagValue(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleBulkTag()}
+              autoFocus
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setBulkTagOpen(false);
+                  setBulkTagValue("");
+                }}
+              >
+                Abbrechen
+              </Button>
+              <Button size="sm" onClick={handleBulkTag} disabled={!bulkTagValue.trim()}>
+                Anwenden
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Detail Sheet */}
+      <Sheet open={detailOpen} onOpenChange={setDetailOpen}>
+        <SheetContent side="right" className="w-full sm:max-w-lg flex flex-col p-0" showCloseButton>
+          {detailAsset && (
+            <>
+              <SheetHeader className="px-4 pt-4 pb-0">
+                <SheetTitle className="truncate">
+                  {detailAsset.title ?? detailAsset.fileName}
+                </SheetTitle>
+              </SheetHeader>
+
+              <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+                {/* Preview */}
+                <div className="rounded-lg border overflow-hidden bg-muted/30">
+                  {detailAsset.type === "image" ? (
+                    <img
+                      src={api.getMediaFileUrl(customerId, projectId, detailAsset.id)}
+                      alt={detailAsset.altText ?? detailAsset.fileName}
+                      className="w-full object-contain max-h-[300px]"
+                    />
+                  ) : (
+                    <div className="flex flex-col items-center justify-center py-12 gap-2">
+                      {typeIcon(detailAsset.type, "h-12 w-12 text-muted-foreground")}
+                      <span className="text-sm text-muted-foreground">{detailAsset.fileName}</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Metadata Info */}
+                <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                  <div>Typ: <span className="text-foreground">{detailAsset.mimeType}</span></div>
+                  <div>Größe: <span className="text-foreground">{formatFileSize(detailAsset.fileSize)}</span></div>
+                  {detailAsset.width && detailAsset.height && (
+                    <div>Maße: <span className="text-foreground">{detailAsset.width}x{detailAsset.height}</span></div>
+                  )}
+                  <div>Quelle: <span className="text-foreground capitalize">{detailAsset.source}</span></div>
+                </div>
+
+                {/* Editable Fields */}
+                <div className="space-y-3">
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Titel</label>
+                    <Input
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      placeholder="Asset-Titel..."
+                      className="h-9"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Beschreibung</label>
+                    <Input
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      placeholder="Beschreibung..."
+                      className="h-9"
+                    />
+                  </div>
+                  {detailAsset.type === "image" && (
+                    <div>
+                      <label className="text-xs font-medium text-muted-foreground mb-1 block">Alt-Text</label>
+                      <Input
+                        value={editAltText}
+                        onChange={(e) => setEditAltText(e.target.value)}
+                        placeholder="Beschreibung für Screenreader..."
+                        className="h-9"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Tags */}
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground mb-2 block">Tags</label>
+                  <div className="flex flex-wrap gap-1.5 mb-2">
+                    {editTags.map((tag) => (
+                      <Badge key={tag} variant="secondary" className="text-xs gap-1">
+                        {tag}
+                        <button
+                          type="button"
+                          onClick={() => removeTag(tag)}
+                          className="ml-0.5 hover:text-destructive"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <Input
+                      value={newTag}
+                      onChange={(e) => setNewTag(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && addTag()}
+                      placeholder="Neuen Tag hinzufügen..."
+                      className="h-8 text-sm"
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2"
+                      onClick={addTag}
+                      disabled={!newTag.trim()}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Used By */}
+                {detailAsset.usedBy.length > 0 && (
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-2 block">
+                      Verwendet in ({detailAsset.usedBy.length})
+                    </label>
+                    <div className="space-y-1.5">
+                      {detailAsset.usedBy.map((ref, idx) => (
+                        <div
+                          key={`${ref.contentId}-${idx}`}
+                          className="flex items-center gap-2 text-xs rounded border px-2.5 py-1.5"
+                        >
+                          <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <a
+                            href={`/content/${ref.contentId}`}
+                            className="truncate flex-1 text-primary hover:underline"
+                          >
+                            {usageTitles[ref.contentId] ?? ref.contentId.slice(0, 8) + "..."}
+                          </a>
+                          <Badge variant="outline" className="text-[10px] h-4 px-1">
+                            {ref.role}
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Generation Info */}
+                {detailAsset.generationPrompt && (
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                      Generation Prompt
+                    </label>
+                    <p className="text-xs text-muted-foreground bg-muted/50 rounded p-2">
+                      {detailAsset.generationPrompt}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Footer Actions */}
+              <div className="border-t px-4 py-3 flex items-center gap-2">
+                <Button onClick={handleSaveDetail} disabled={saving} className="flex-1">
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : null}
+                  Speichern
+                </Button>
+                <Button
+                  variant="outline"
+                  className="text-destructive hover:text-destructive"
+                  onClick={handleDeleteDetail}
+                  disabled={deleting}
+                >
+                  {deleting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/frontend/src/components/media-picker.tsx
+++ b/frontend/src/components/media-picker.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Upload, Sparkles, Search, ImageIcon, Film, FileText, Music } from "lucide-react";
+import { useProject } from "@/lib/project-context";
+import type { MediaAsset, MediaType } from "@/lib/types";
+import * as api from "@/lib/api";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+interface MediaPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (asset: MediaAsset) => void;
+  /** Filter by media type */
+  typeFilter?: "image" | "video" | "audio" | "document";
+  /** Pre-selected asset */
+  selectedId?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+const TYPE_TABS: { value: string; label: string; icon: React.ReactNode }[] = [
+  { value: "all", label: "Alle", icon: null },
+  { value: "image", label: "Bilder", icon: <ImageIcon className="h-3.5 w-3.5" /> },
+  { value: "video", label: "Videos", icon: <Film className="h-3.5 w-3.5" /> },
+  { value: "document", label: "Dokumente", icon: <FileText className="h-3.5 w-3.5" /> },
+];
+
+function typeIcon(type: MediaType) {
+  switch (type) {
+    case "image":
+      return <ImageIcon className="h-8 w-8 text-muted-foreground" />;
+    case "video":
+      return <Film className="h-8 w-8 text-muted-foreground" />;
+    case "audio":
+      return <Music className="h-8 w-8 text-muted-foreground" />;
+    case "document":
+      return <FileText className="h-8 w-8 text-muted-foreground" />;
+    default:
+      return <FileText className="h-8 w-8 text-muted-foreground" />;
+  }
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ── Component ─────────────────────────────────────────────────────
+
+export function MediaPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  typeFilter,
+  selectedId,
+}: MediaPickerProps) {
+  const { customerId, projectId } = useProject();
+
+  // State
+  const [assets, setAssets] = useState<MediaAsset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState("");
+  const [activeType, setActiveType] = useState<string>(typeFilter ?? "all");
+  const [selected, setSelected] = useState<MediaAsset | null>(null);
+  const [altText, setAltText] = useState("");
+  const [uploading, setUploading] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ── Load assets ──────────────────────────────────────────────────
+
+  const loadAssets = useCallback(async () => {
+    if (!customerId || !projectId) return;
+    setLoading(true);
+    try {
+      const typeParam = activeType !== "all" ? activeType : typeFilter;
+      const result = await api.getMedia(customerId, projectId, {
+        type: typeParam,
+        search: search || undefined,
+      });
+      setAssets(result.assets);
+    } catch {
+      // API error -- grid bleibt leer
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId, projectId, activeType, search, typeFilter]);
+
+  useEffect(() => {
+    if (open) {
+      loadAssets();
+    }
+  }, [open, loadAssets]);
+
+  // Sync selected asset when selectedId changes
+  useEffect(() => {
+    if (selectedId && assets.length > 0) {
+      const found = assets.find((a) => a.id === selectedId);
+      if (found) {
+        setSelected(found);
+        setAltText(found.altText ?? "");
+      }
+    }
+  }, [selectedId, assets]);
+
+  // Reset on close
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setSelected(null);
+      setAltText("");
+      if (!typeFilter) setActiveType("all");
+    }
+  }, [open, typeFilter]);
+
+  // ── Upload handler ───────────────────────────────────────────────
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !customerId || !projectId) return;
+    setUploading(true);
+    try {
+      const result = await api.uploadMedia(customerId, projectId, file);
+      setAssets((prev) => [result.asset, ...prev]);
+      setSelected(result.asset);
+      setAltText(result.asset.altText ?? "");
+    } catch {
+      // Upload fehlgeschlagen
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  // ── Select handler ───────────────────────────────────────────────
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    onSelect({ ...selected, altText: altText || selected.altText });
+    onOpenChange(false);
+  };
+
+  // ── Render ───────────────────────────────────────────────────────
+
+  const showGenerateButton = typeFilter === "image" || (!typeFilter && activeType === "image");
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-[480px] flex flex-col p-0" showCloseButton>
+        {/* Header */}
+        <SheetHeader className="px-4 pt-4 pb-0">
+          <SheetTitle>Media Library</SheetTitle>
+        </SheetHeader>
+
+        {/* Search + Actions */}
+        <div className="px-4 pt-3 pb-2 space-y-3 border-b">
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Suchen..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-8 h-9"
+              />
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept="image/*,video/*,audio/*,.pdf,.doc,.docx"
+              onChange={handleUpload}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+            >
+              <Upload className="h-4 w-4 mr-1.5" />
+              Upload
+            </Button>
+            {showGenerateButton && (
+              <Button variant="outline" size="sm" className="h-9">
+                <Sparkles className="h-4 w-4 mr-1.5" />
+                Generate
+              </Button>
+            )}
+          </div>
+
+          {/* Type Tabs */}
+          {!typeFilter && (
+            <Tabs value={activeType} onValueChange={setActiveType}>
+              <TabsList className="w-full">
+                {TYPE_TABS.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value} className="flex-1 text-xs">
+                    {tab.icon && <span className="mr-1">{tab.icon}</span>}
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          )}
+        </div>
+
+        {/* Asset Grid */}
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {loading ? (
+            <div className="flex items-center justify-center h-40">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            </div>
+          ) : assets.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-40 text-center">
+              <ImageIcon className="h-8 w-8 text-muted-foreground mb-2" />
+              <p className="text-sm text-muted-foreground">Keine Medien gefunden</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-2">
+              {assets.map((asset) => {
+                const isSelected = selected?.id === asset.id;
+                return (
+                  <button
+                    key={asset.id}
+                    type="button"
+                    onClick={() => {
+                      setSelected(asset);
+                      setAltText(asset.altText ?? "");
+                    }}
+                    className={`relative aspect-video rounded-md border overflow-hidden transition-all hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                      isSelected ? "ring-2 ring-primary border-primary" : ""
+                    }`}
+                  >
+                    {asset.type === "image" ? (
+                      <img
+                        src={api.getMediaThumbnailUrl(customerId, projectId, asset.id)}
+                        alt={asset.altText ?? asset.fileName}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                        onError={(e) => {
+                          // Fallback auf File-URL wenn kein Thumbnail existiert
+                          const img = e.currentTarget;
+                          if (!img.dataset.fallback) {
+                            img.dataset.fallback = "1";
+                            img.src = api.getMediaFileUrl(customerId, projectId, asset.id);
+                          }
+                        }}
+                      />
+                    ) : (
+                      <div className="w-full h-full flex flex-col items-center justify-center bg-muted/50 gap-1">
+                        {typeIcon(asset.type)}
+                        <span className="text-[10px] text-muted-foreground truncate max-w-full px-1">
+                          {asset.fileName}
+                        </span>
+                      </div>
+                    )}
+                    {/* Source Badge */}
+                    {asset.source === "generated" && (
+                      <Badge
+                        variant="secondary"
+                        className="absolute top-1 right-1 text-[9px] px-1 py-0 h-4"
+                      >
+                        AI
+                      </Badge>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer: Selected Asset + Confirm */}
+        {selected && (
+          <div className="border-t px-4 py-3 space-y-3">
+            <div className="flex items-center gap-3">
+              {/* Kleine Preview */}
+              <div className="w-16 h-12 rounded border overflow-hidden shrink-0">
+                {selected.type === "image" ? (
+                  <img
+                    src={api.getMediaThumbnailUrl(customerId, projectId, selected.id)}
+                    alt={selected.altText ?? selected.fileName}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center bg-muted/50">
+                    {typeIcon(selected.type)}
+                  </div>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium truncate">{selected.title ?? selected.fileName}</p>
+                <p className="text-xs text-muted-foreground">
+                  {selected.mimeType} &middot; {formatFileSize(selected.fileSize)}
+                  {selected.width && selected.height && (
+                    <> &middot; {selected.width}x{selected.height}</>
+                  )}
+                </p>
+              </div>
+            </div>
+
+            {/* Alt-Text Input (nur bei Bildern) */}
+            {selected.type === "image" && (
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Alt-Text
+                </label>
+                <Input
+                  value={altText}
+                  onChange={(e) => setAltText(e.target.value)}
+                  placeholder="Beschreibung des Bildes..."
+                  className="h-8 text-sm"
+                />
+              </div>
+            )}
+
+            <Button onClick={handleConfirm} className="w-full">
+              Auswählen
+            </Button>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   CalendarDays,
   Activity,
   Cable,
+  ImageIcon,
   MoreHorizontal,
   Pencil,
   Trash2,
@@ -313,8 +314,20 @@ export function Sidebar() {
         </div>
       </div>
 
-      {/* Monitor */}
-      <div className="px-3 pb-1">
+      {/* Media + Monitor */}
+      <div className="px-3 pb-1 space-y-0.5">
+        <Link
+          href="/media"
+          className={cn(
+            "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            (pathname === "/media" || pathname.startsWith("/media/"))
+              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+          )}
+        >
+          <ImageIcon className="h-4 w-4" />
+          Media
+        </Link>
         <Link
           href="/monitor"
           className={cn(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Customer, Project, Topic, Category, Author, PipelineRun, ContentItem, ContentVersion, ContentType, ContentItemStatus, ContentIndex, ChatMessage, ContentMediaAsset, FlowInput } from "./types";
+import type { Customer, Project, Topic, Category, Author, PipelineRun, ContentItem, ContentVersion, ContentType, ContentItemStatus, ContentIndex, ChatMessage, ContentMediaAsset, FlowInput, MediaAsset } from "./types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:6100";
 
@@ -683,4 +683,138 @@ export async function getGitHubFile(installationId: number, owner: string, repo:
   const res = await fetch(`${API_URL}/github/repos/${owner}/${repo}/file?${params}`);
   if (!res.ok) throw new Error(`Failed to load file: ${res.status}`);
   return res.text();
+}
+
+// ── Media Library ────────────────────────────────────────────────
+
+export function getMedia(
+  customerId: string,
+  projectId: string,
+  filters?: { type?: string; source?: string; tags?: string; search?: string; unused?: boolean; page?: number; limit?: number },
+): Promise<{ total: number; assets: MediaAsset[] }> {
+  const params = new URLSearchParams();
+  if (filters?.type) params.set("type", filters.type);
+  if (filters?.source) params.set("source", filters.source);
+  if (filters?.tags) params.set("tags", filters.tags);
+  if (filters?.search) params.set("search", filters.search);
+  if (filters?.unused) params.set("unused", "true");
+  if (filters?.page) params.set("page", String(filters.page));
+  if (filters?.limit) params.set("limit", String(filters.limit));
+  const qs = params.toString();
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media${qs ? `?${qs}` : ""}`);
+}
+
+export function getMediaTags(
+  customerId: string,
+  projectId: string,
+): Promise<{ tags: { tag: string; count: number }[] }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/tags`);
+}
+
+export function getMediaAsset(
+  customerId: string,
+  projectId: string,
+  assetId: string,
+): Promise<MediaAsset> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}`);
+}
+
+export function updateMediaAsset(
+  customerId: string,
+  projectId: string,
+  assetId: string,
+  data: { title?: string; description?: string; tags?: string[]; altText?: string },
+): Promise<MediaAsset> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteMediaAsset(
+  customerId: string,
+  projectId: string,
+  assetId: string,
+  force?: boolean,
+): Promise<{ message: string }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}${force ? "?force=true" : ""}`, {
+    method: "DELETE",
+  });
+}
+
+export async function uploadMedia(
+  customerId: string,
+  projectId: string,
+  file: File,
+  metadata?: { title?: string; description?: string; tags?: string[] },
+): Promise<{ asset: MediaAsset; thumbnailGenerated: boolean }> {
+  const formData = new FormData();
+  formData.append("file", file);
+  if (metadata?.title) formData.append("title", metadata.title);
+  if (metadata?.description) formData.append("description", metadata.description);
+  if (metadata?.tags) formData.append("tags", JSON.stringify(metadata.tags));
+  const res = await fetch(
+    `${API_URL}/customers/${customerId}/projects/${projectId}/media/upload`,
+    { method: "POST", body: formData },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error((body as { error?: string }).error ?? `Upload failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export function bulkUpdateMedia(
+  customerId: string,
+  projectId: string,
+  data: { assetIds: string[]; addTags?: string[]; removeTags?: string[] },
+): Promise<{ updated: string[]; notFound: string[] }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/bulk/update`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function bulkDeleteMedia(
+  customerId: string,
+  projectId: string,
+  assetIds: string[],
+  force?: boolean,
+): Promise<{ deleted: string[]; notFound: string[]; inUse: string[] }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/bulk/delete`, {
+    method: "POST",
+    body: JSON.stringify({ assetIds, force }),
+  });
+}
+
+export function getMediaFileUrl(customerId: string, projectId: string, assetId: string): string {
+  return `${API_URL}/customers/${customerId}/projects/${projectId}/media/${assetId}/file`;
+}
+
+export function getMediaThumbnailUrl(customerId: string, projectId: string, assetId: string): string {
+  return `${API_URL}/customers/${customerId}/projects/${projectId}/media/${assetId}/thumbnail`;
+}
+
+export function addMediaUsage(
+  customerId: string,
+  projectId: string,
+  assetId: string,
+  contentId: string,
+  role: "hero" | "inline" | "thumbnail" | "attachment" | "social_media",
+): Promise<{ message: string }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}/usage`, {
+    method: "POST",
+    body: JSON.stringify({ contentId, role }),
+  });
+}
+
+export function removeMediaUsage(
+  customerId: string,
+  projectId: string,
+  assetId: string,
+  contentId: string,
+): Promise<{ message: string }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}/usage/${contentId}`, {
+    method: "DELETE",
+  });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -134,6 +134,34 @@ export interface NewsletterVersionMeta {
 export type MediaType = "image" | "video" | "audio" | "document";
 export type MediaSource = "generated" | "uploaded" | "extracted";
 
+export interface MediaAsset {
+  id: string;
+  customerId: string;
+  projectId: string;
+  type: MediaType;
+  source: MediaSource;
+  mimeType: string;
+  fileName: string;
+  fileSize: number;
+  localPath: string;
+  cdnUrl?: string;
+  width?: number;
+  height?: number;
+  altText?: string;
+  title?: string;
+  description?: string;
+  tags: string[];
+  usedBy: { contentId: string; role: string; addedAt: string }[];
+  durationSeconds?: number;
+  resolution?: string;
+  thumbnailPath?: string;
+  generationPrompt?: string;
+  generationModel?: string;
+  generationCostUsd?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ContentMediaAsset {
   id: string;
   contentId: string;


### PR DESCRIPTION
## Summary

- **Backend**: MediaAsset erweitert um `title`, `description`, `tags[]`, `usedBy[]`. 17 API-Endpunkte (Listing mit Filter/Pagination, Tags-Aggregation, PATCH-Metadaten, Bulk-Upload/Update/Delete, File/Thumbnail-Streaming, Usage-Tracking, AI-Bildgenerierung via Imagen)
- **Frontend**: MediaPage mit Grid-Ansicht, Such-/Filter-Bar (Typ, Quelle, Tags), Bulk-Aktionen (Tag, Delete), Detail-Sheet mit Metadaten-Editor und Usage-Anzeige
- **MediaPicker**: Wiederverwendbare Sheet-Komponente zur Asset-Auswahl mit Upload, Type-Tabs und Alt-Text-Eingabe
- **Sidebar**: Media-Link hinzugefügt

## Test Plan

- [ ] Media-Seite laden (`/media`)
- [ ] Datei hochladen (Bild + Dokument)
- [ ] Filter testen (Typ, Quelle, Suche)
- [ ] Detail-Sheet: Titel, Beschreibung, Tags bearbeiten
- [ ] Bulk-Auswahl: Tag hinzufügen, löschen
- [ ] Thumbnail- und File-Streaming prüfen
- [ ] TypeScript kompiliert fehlerfrei (Backend + Frontend)