### PR TITLE
feat(connector): Shopware 6 Connector UI, Schema Discovery + Browse API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ docker-compose.override.yml
 .vscode/
 .idea/
 *.code-workspace
+
+# Claude Code (contributor-specific)
+CLAUDE.md

--- a/backend/src/api/routes/connectors.ts
+++ b/backend/src/api/routes/connectors.ts
@@ -1,0 +1,351 @@
+import type { FastifyInstance } from "fastify";
+import { createLogger } from "../../utils/logger.js";
+import { ShopwareSiteConnector } from "../../connectors/site/shopware.js";
+import { createSiteConnector } from "../../connectors/site/factory.js";
+
+const log = createLogger("api:connectors");
+
+export async function connectorRoutes(app: FastifyInstance) {
+  // POST /connectors/test — test connector credentials
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: {
+      type: string;
+      config: {
+        shopUrl?: string;
+        clientId?: string;
+        clientSecret?: string;
+      };
+    };
+  }>("/test", async (request, reply) => {
+    const { type, config } = request.body;
+
+    if (type === "shopware") {
+      if (!config.shopUrl || !config.clientId || !config.clientSecret) {
+        return reply.status(400).send({ success: false, error: "shopUrl, clientId, clientSecret sind erforderlich" });
+      }
+
+      try {
+        // Normalize URL (remove trailing slash)
+        const shopUrl = config.shopUrl.replace(/\/+$/, "");
+
+        // Try to get OAuth token
+        const res = await fetch(`${shopUrl}/api/oauth/token`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            grant_type: "client_credentials",
+            client_id: config.clientId,
+            client_secret: config.clientSecret,
+          }),
+        });
+
+        if (!res.ok) {
+          const body = await res.text();
+          log.warn({ status: res.status, body }, "Shopware connection test failed");
+          return reply.status(200).send({
+            success: false,
+            error: res.status === 401
+              ? "Authentifizierung fehlgeschlagen -- Client ID oder Secret falsch"
+              : `Shopware API Fehler: ${res.status}`,
+          });
+        }
+
+        // Token works, try to get shop info
+        const tokenData = await res.json() as { access_token: string };
+        let shopName: string | undefined;
+        try {
+          const infoRes = await fetch(`${shopUrl}/api/_info/config`, {
+            headers: { Authorization: `Bearer ${tokenData.access_token}`, Accept: "application/json" },
+          });
+          if (infoRes.ok) {
+            const info = await infoRes.json() as { version?: string; title?: string };
+            shopName = info.title;
+          }
+        } catch {
+          // Info endpoint optional
+        }
+
+        log.info({ shopUrl, shopName }, "Shopware connection test successful");
+        return { success: true, shopName, shopUrl };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Verbindung fehlgeschlagen";
+        log.error({ err, shopUrl: config.shopUrl }, "Shopware connection test error");
+        return reply.status(200).send({ success: false, error: message });
+      }
+    }
+
+    return reply.status(400).send({ success: false, error: `Connector-Typ "${type}" wird nicht unterstützt` });
+  });
+
+  // GET /connectors/schemas — discover schemas from configured connector
+  app.get<{
+    Params: { customerId: string; projectId: string };
+  }>("/schemas", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const projects = app.ctx.projectsFor(customerId);
+    const project = projects.get(projectId);
+
+    if (!project) {
+      return reply.status(404).send({ error: "Project not found" });
+    }
+
+    const connectorType = project.connector?.type;
+    if (connectorType !== "shopware" && connectorType !== "wordpress") {
+      return reply.status(400).send({ error: "Kein Connector mit Schema Discovery konfiguriert" });
+    }
+
+    try {
+      const connector = createSiteConnector(project);
+      if (!connector.discoverSchemas) {
+        return reply.status(400).send({ error: "Connector unterstützt keine Schema Discovery" });
+      }
+
+      const schemas = await connector.discoverSchemas();
+      log.info({ connectorType, schemaCount: schemas.length }, "schemas discovered");
+      return { schemas };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Schema Discovery fehlgeschlagen";
+      log.error({ err, connectorType }, "schema discovery failed");
+      return reply.status(500).send({ error: message });
+    }
+  });
+
+  // GET /connectors/browse — browse connector content (products, categories)
+  app.get<{
+    Params: { customerId: string; projectId: string };
+    Querystring: {
+      entity?: string;
+      search?: string;
+      categoryId?: string;
+      page?: string;
+      limit?: string;
+    };
+  }>("/browse", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const { entity = "products", search, categoryId, page = "1", limit = "20" } = request.query;
+
+    const projects = app.ctx.projectsFor(customerId);
+    const project = projects.get(projectId);
+    if (!project) return reply.status(404).send({ error: "Project not found" });
+
+    if (project.connector?.type !== "shopware") {
+      return reply.status(400).send({ error: "Nur Shopware-Connector unterstützt Browse" });
+    }
+
+    const sw = project.connector.shopware;
+    if (!sw?.shopUrl || !sw?.clientId || !sw?.clientSecret) {
+      return reply.status(400).send({ error: "Shopware-Connector nicht konfiguriert" });
+    }
+
+    const connector = new ShopwareSiteConnector(sw);
+
+    try {
+      if (entity === "products") {
+        const result = await browseProducts(connector, search, categoryId, parseInt(page), parseInt(limit));
+        return result;
+      } else if (entity === "categories") {
+        const result = await browseCategories(connector, search);
+        return result;
+      }
+      return reply.status(400).send({ error: `Unbekannte Entity: ${entity}` });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Browse fehlgeschlagen";
+      log.error({ err, entity }, "connector browse failed");
+      return reply.status(500).send({ error: message });
+    }
+  });
+
+  // GET /connectors/browse/:refId — get detail for a specific item
+  app.get<{
+    Params: { customerId: string; projectId: string; refId: string };
+    Querystring: { entity?: string };
+  }>("/browse/:refId", async (request, reply) => {
+    const { customerId, projectId, refId } = request.params;
+    const { entity = "products" } = request.query;
+
+    const projects = app.ctx.projectsFor(customerId);
+    const project = projects.get(projectId);
+    if (!project) return reply.status(404).send({ error: "Project not found" });
+
+    if (project.connector?.type !== "shopware") {
+      return reply.status(400).send({ error: "Nur Shopware-Connector unterstützt Browse" });
+    }
+
+    const sw = project.connector.shopware;
+    if (!sw?.shopUrl || !sw?.clientId || !sw?.clientSecret) {
+      return reply.status(400).send({ error: "Shopware-Connector nicht konfiguriert" });
+    }
+
+    const connector = new ShopwareSiteConnector(sw);
+
+    try {
+      if (entity === "products") {
+        const detail = await getProductDetail(connector, refId);
+        return detail;
+      }
+      return reply.status(400).send({ error: `Unbekannte Entity: ${entity}` });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Detail-Abruf fehlgeschlagen";
+      log.error({ err, refId, entity }, "connector browse detail failed");
+      return reply.status(500).send({ error: message });
+    }
+  });
+}
+
+// ── Shopware Browse Helpers ─────────────────────────────────────
+
+async function browseProducts(
+  connector: ShopwareSiteConnector,
+  search: string | undefined,
+  categoryId: string | undefined,
+  page: number,
+  limit: number,
+) {
+  const filters: Record<string, unknown>[] = [
+    { type: "equals", field: "active", value: true },
+    { type: "equals", field: "parentId", value: null }, // no variants
+  ];
+
+  if (categoryId) {
+    filters.push({ type: "equals", field: "categories.id", value: categoryId });
+  }
+
+  const body: Record<string, unknown> = {
+    filter: filters,
+    page,
+    limit,
+    includes: {
+      product: ["id", "name", "productNumber", "description", "active"],
+    },
+    "total-count-mode": 1,
+  };
+
+  if (search && search.length >= 2) {
+    body.query = [
+      { score: 500, query: { type: "contains", field: "name", value: search } },
+      { score: 200, query: { type: "contains", field: "description", value: search } },
+      { score: 100, query: { type: "contains", field: "productNumber", value: search } },
+    ];
+  }
+
+  // Access internal apiPost via casting -- ShopwareSiteConnector exposes only public methods
+  // We need to call the search endpoint, so we add a public method
+  const result = await connector.apiPost(
+    "/search/product",
+    body,
+  );
+
+  const data = result as { data: Array<{ id: string; name: string; productNumber: string; description?: string }>; total: number };
+
+  return {
+    total: data.total ?? 0,
+    items: (data.data ?? []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      productNumber: p.productNumber,
+      description: p.description ? stripHtml(p.description).slice(0, 200) : undefined,
+    })),
+  };
+}
+
+async function browseCategories(connector: ShopwareSiteConnector, search: string | undefined) {
+  const filters: Record<string, unknown>[] = [
+    { type: "equals", field: "active", value: true },
+    { type: "not", queries: [{ type: "equals", field: "type", value: "folder" }] },
+    { type: "not", queries: [{ type: "equals", field: "type", value: "link" }] },
+  ];
+
+  const body: Record<string, unknown> = {
+    filter: filters,
+    limit: 100,
+    includes: {
+      category: ["id", "name", "type", "level", "parentId", "childCount"],
+    },
+  };
+
+  if (search && search.length >= 2) {
+    body.query = [
+      { score: 500, query: { type: "contains", field: "name", value: search } },
+    ];
+  }
+
+  const result = await connector.apiPost(
+    "/search/category",
+    body,
+  );
+
+  const data = result as { data: Array<{ id: string; name: string; type: string; level: number; parentId?: string; childCount: number }>; total: number };
+
+  return {
+    total: data.total ?? 0,
+    items: (data.data ?? []).map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      level: c.level,
+      childCount: c.childCount,
+    })),
+  };
+}
+
+async function getProductDetail(connector: ShopwareSiteConnector, productId: string) {
+  const body = {
+    ids: [productId],
+    associations: {
+      cover: { associations: { media: {} } },
+      properties: { associations: { group: {} } },
+    },
+    includes: {
+      product: ["id", "name", "productNumber", "description", "price", "cover", "properties", "metaTitle", "metaDescription"],
+      product_media: ["media"],
+      media: ["url", "alt", "title"],
+      property_group_option: ["name", "group"],
+      property_group: ["name"],
+    },
+  };
+
+  const result = await connector.apiPost(
+    "/search/product",
+    body,
+  );
+
+  const data = result as { data: Array<Record<string, unknown>> };
+  const product = data.data?.[0];
+  if (!product) return { error: "Produkt nicht gefunden" };
+
+  // Build structured text for FlowInput
+  const parts: string[] = [];
+  parts.push(`Produkt: ${product.name}`);
+  if (product.productNumber) parts.push(`Artikelnummer: ${product.productNumber}`);
+  if (product.description) parts.push(`Beschreibung: ${stripHtml(String(product.description))}`);
+
+  // Properties
+  const props = product.properties as Array<{ name: string; group?: { name: string } }> | undefined;
+  if (props && props.length > 0) {
+    const propTexts = props.map((p) => `${p.group?.name ?? "Eigenschaft"}: ${p.name}`);
+    parts.push(`Eigenschaften: ${propTexts.join(", ")}`);
+  }
+
+  // Price
+  const price = product.price as Array<{ gross: number; net: number; currencyId: string }> | undefined;
+  if (price && price.length > 0) {
+    parts.push(`Preis: ${price[0].gross.toFixed(2)} EUR (brutto)`);
+  }
+
+  // Cover image
+  const cover = product.cover as { media?: { url?: string; alt?: string } } | undefined;
+  const imageUrl = cover?.media?.url;
+
+  return {
+    id: product.id,
+    name: product.name,
+    productNumber: product.productNumber,
+    structuredText: parts.join("\n"),
+    imageUrl,
+  };
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").replace(/\s+/g, " ").trim();
+}

--- a/backend/src/api/routes/content-types.ts
+++ b/backend/src/api/routes/content-types.ts
@@ -124,10 +124,14 @@ export async function contentTypeRoutes(app: FastifyInstance) {
   );
 
   // POST /content-types/import — Import schemas from connector
-  app.post<{ Params: { customerId: string; projectId: string } }>(
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: { schemaIds?: string[] };
+  }>(
     "/import",
     async (request, reply) => {
       const { customerId, projectId } = request.params;
+      const body = (request.body ?? {}) as { schemaIds?: string[] };
       const project = app.ctx.projectsFor(customerId).get(projectId);
       if (!project) {
         return reply.status(404).send({ error: "Project not found" });
@@ -141,11 +145,18 @@ export async function contentTypeRoutes(app: FastifyInstance) {
           });
         }
 
-        const schemas = await connector.discoverSchemas();
+        let schemas = await connector.discoverSchemas();
+
+        // Filter by selected schema IDs if provided
+        if (body.schemaIds && body.schemaIds.length > 0) {
+          const idSet = new Set(body.schemaIds);
+          schemas = schemas.filter((s) => idSet.has(s.id));
+        }
+
         const store = getStore(customerId, projectId);
         const imported = store.importFromConnector(projectId, connector.platform, schemas);
 
-        log.info({ projectId, connector: connector.platform, count: imported.length }, "schemas imported");
+        log.info({ projectId, connector: connector.platform, count: imported.length, filtered: !!body.schemaIds }, "schemas imported");
         return { message: `${imported.length} content types imported`, types: imported };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -23,6 +23,7 @@ import { contentIndexRoutes } from "./routes/content-index.js";
 import { contentRoutes } from "./routes/content.js";
 import { mediaRoutes } from "./routes/media.js";
 import { contentTypeRoutes } from "./routes/content-types.js";
+import { connectorRoutes } from "./routes/connectors.js";
 
 const log = createLogger("server");
 
@@ -96,6 +97,7 @@ export async function buildServer(dataDir: string) {
   await app.register(mediaRoutes, { prefix: "/customers/:customerId/projects/:projectId/media" });
   await app.register(contentIndexRoutes, { prefix: "/customers/:customerId/projects/:projectId/content-index" });
   await app.register(contentTypeRoutes, { prefix: "/customers/:customerId/projects/:projectId/content-types" });
+  await app.register(connectorRoutes, { prefix: "/customers/:customerId/projects/:projectId/connectors" });
 
   // Error handler
   app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {

--- a/backend/src/connectors/site/shopware.ts
+++ b/backend/src/connectors/site/shopware.ts
@@ -70,6 +70,21 @@ export class ShopwareSiteConnector implements SiteConnector {
     return res.json() as Promise<T>;
   }
 
+  async apiPost<T>(path: string, body: unknown): Promise<T> {
+    const token = await this.getToken();
+    const res = await fetch(`${this.config.shopUrl}/api${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`Shopware API POST ${path}: ${res.status}`);
+    return res.json() as Promise<T>;
+  }
+
   private async apiPatch(path: string, body: unknown): Promise<void> {
     const token = await this.getToken();
     const res = await fetch(`${this.config.shopUrl}/api${path}`, {
@@ -106,8 +121,8 @@ export class ShopwareSiteConnector implements SiteConnector {
   async discoverSchemas(): Promise<ConnectorSchema[]> {
     log.info("discovering Shopware CMS layouts");
 
-    // Fetch all CMS pages of type "landingpage" with full structure
-    const result = await this.apiGet<{
+    // Use POST /search/cms-page for reliable association loading
+    const result = await this.apiPost<{
       data: Array<{
         id: string;
         name: string;
@@ -126,7 +141,21 @@ export class ShopwareSiteConnector implements SiteConnector {
           }>;
         }>;
       }>;
-    }>("/cms-page?filter[type]=landingpage&associations[sections][associations][blocks][associations][slots]=true&limit=50");
+    }>("/search/cms-page", {
+      filter: [{ type: "equals", field: "type", value: "landingpage" }],
+      associations: {
+        sections: {
+          associations: {
+            blocks: {
+              associations: {
+                slots: {},
+              },
+            },
+          },
+        },
+      },
+      limit: 50,
+    });
 
     const schemas: ConnectorSchema[] = [];
 

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -82,6 +82,7 @@ export interface Competitor {
 
 export interface ConnectorConfig {
   type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "api";
+  useAsSource?: boolean;
   git?: {
     repoUrl: string;
     branch: string;

--- a/frontend/src/app/connectors/page.tsx
+++ b/frontend/src/app/connectors/page.tsx
@@ -21,6 +21,9 @@ import {
   updateProject,
   getGitHubRepos,
   getGitHubBranches,
+  testConnector,
+  getConnectorSchemas,
+  importConnectorSchemas,
 } from "@/lib/api";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -31,6 +34,7 @@ import {
   Github,
   GitBranch,
   ChevronLeft,
+  ChevronDown,
   Info,
   Globe,
   Linkedin,
@@ -80,8 +84,8 @@ const FRAMEWORKS: FrameworkDef[] = [
 
 const CONNECTORS: ConnectorDef[] = [
   { id: "git", name: "Git Repository", category: "site", icon: GitBranch, description: "Push content to a Git repository", comingSoon: false },
+  { id: "shopware", name: "Shopware 6", category: "site", icon: ShoppingBag, description: "Read Shopping Experiences, write CMS slots", comingSoon: false },
   { id: "wordpress", name: "WordPress", category: "site", icon: Globe, description: "Publish directly via WordPress API", comingSoon: true },
-  { id: "shopify", name: "Shopify", category: "site", icon: ShoppingBag, description: "Publish to Shopify blog", comingSoon: true },
   { id: "webflow", name: "Webflow", category: "site", icon: Aperture, description: "Publish to Webflow CMS", comingSoon: true },
   { id: "linkedin", name: "LinkedIn", category: "social", icon: Linkedin, description: "Post to LinkedIn", comingSoon: true },
   { id: "instagram", name: "Instagram", category: "social", icon: Instagram, description: "Post to Instagram", comingSoon: true },
@@ -125,7 +129,7 @@ async function withSave(setStatus: (s: SaveStatus) => void, fn: () => Promise<vo
 // ── Main Page Content ────────────────────────────────────────────
 
 function ConnectorsPageContent() {
-  const { customerId, projectId, project, loading: projectLoading } = useProject();
+  const { customerId, projectId, project, loading: projectLoading, refreshProjects } = useProject();
   const searchParams = useSearchParams();
 
   // Git connector state
@@ -146,6 +150,23 @@ function ConnectorsPageContent() {
   const [connectorStatus, setConnectorStatus] = useState<SaveStatus>("idle");
   const [detailView, setDetailView] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
+
+  // Shopware connector state
+  const [swShopUrl, setSwShopUrl] = useState("");
+  const [swClientId, setSwClientId] = useState("");
+  const [swClientSecret, setSwClientSecret] = useState("");
+  const [swAsSource, setSwAsSource] = useState(false);
+  const [swTestStatus, setSwTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
+  const [swTestError, setSwTestError] = useState("");
+  const [swTestShopName, setSwTestShopName] = useState("");
+  const [swSaveStatus, setSwSaveStatus] = useState<SaveStatus>("idle");
+  const [swSchemas, setSwSchemas] = useState<Array<{ id: string; label: string; description: string; slots: unknown[] }>>([]);
+  const [swSchemasLoading, setSwSchemasLoading] = useState(false);
+  const [swSelectedSchemas, setSwSelectedSchemas] = useState<Set<string>>(new Set());
+  const [swImporting, setSwImporting] = useState(false);
+  const [swExpandedSchema, setSwExpandedSchema] = useState<string | null>(null);
+  // Map: connectorRef (schema.id) → content type ID (slug) for delete
+  const [swSchemaToTypeId, setSwSchemaToTypeId] = useState<Record<string, string>>({});
 
   const loadGhRepos = useCallback(async (installationId: number) => {
     setGhLoadingRepos(true);
@@ -187,6 +208,13 @@ function ConnectorsPageContent() {
       setGhAssetsPath(project.connector.github.assetsPath);
       setGhCategoriesPath(project.connector.github.categoriesPath ?? "src/data/categories.json");
       setGhAuthorsPath(project.connector.github.authorsPath ?? "src/data/authors.json");
+    }
+    // Load Shopware config
+    if (project.connector?.shopware) {
+      setSwShopUrl(project.connector.shopware.shopUrl ?? "");
+      setSwClientId(project.connector.shopware.clientId ?? "");
+      setSwClientSecret(project.connector.shopware.clientSecret ?? "");
+      setSwAsSource(project.connector.useAsSource ?? false);
     }
     setInitialized(true);
   }, [project, initialized]);
@@ -282,11 +310,102 @@ function ConnectorsPageContent() {
 
   const isGitConnected = connectorType === "github" && !!ghInstallationId;
 
+  const isSwConnected = (project?.connector?.type === "shopware" && !!project?.connector?.shopware?.shopUrl)
+    || (swSaveStatus === "saved" && !!swShopUrl && !!swClientId && !!swClientSecret);
+
+  // Auto-load schemas when entering Shopware detail view
+  useEffect(() => {
+    if (detailView === "shopware" && isSwConnected && swSchemas.length === 0 && !swSchemasLoading && customerId && projectId) {
+      handleSwLoadSchemas();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailView, isSwConnected]);
+
   const getConnectorStatus = (id: string): "connected" | "not_connected" | "coming_soon" => {
     if (id === "git" && isGitConnected) return "connected";
+    if (id === "shopware" && isSwConnected) return "connected";
     const def = CONNECTORS.find((c) => c.id === id);
     if (def?.comingSoon) return "coming_soon";
     return "not_connected";
+  };
+
+  const handleSwTest = async () => {
+    if (!swShopUrl || !swClientId || !swClientSecret) return;
+    setSwTestStatus("testing");
+    setSwTestError("");
+    try {
+      const result = await testConnector(customerId, projectId, {
+        type: "shopware",
+        config: { shopUrl: swShopUrl.replace(/\/+$/, ""), clientId: swClientId, clientSecret: swClientSecret },
+      });
+      if (result.success) {
+        setSwTestStatus("success");
+        setSwTestShopName(result.shopName ?? "");
+      } else {
+        setSwTestStatus("error");
+        setSwTestError(result.error ?? "Unbekannter Fehler");
+      }
+    } catch (err) {
+      setSwTestStatus("error");
+      setSwTestError(err instanceof Error ? err.message : "Verbindung fehlgeschlagen");
+    }
+  };
+
+  const handleSwSave = () => withSave(setSwSaveStatus, async () => {
+    await updateProject(customerId, projectId, {
+      connector: {
+        type: "shopware",
+        shopware: {
+          shopUrl: swShopUrl.replace(/\/+$/, ""),
+          clientId: swClientId,
+          clientSecret: swClientSecret,
+        },
+      },
+    });
+    await refreshProjects();
+  });
+
+  const handleSwLoadSchemas = async () => {
+    if (!customerId || !projectId) return;
+    setSwSchemasLoading(true);
+    try {
+      const [schemasResult, typesResult] = await Promise.all([
+        getConnectorSchemas(customerId, projectId),
+        import("@/lib/api").then((m) => m.getContentTypes(customerId, projectId)),
+      ]);
+      setSwSchemas(schemasResult.schemas);
+      // Mark schemas that are already imported as content types
+      const types = typesResult as Array<{ id: string; connectorRef?: string }>;
+      const importedIds = new Set<string>();
+      const refToId: Record<string, string> = {};
+      for (const t of types) {
+        if (t.connectorRef) {
+          importedIds.add(t.connectorRef);
+          refToId[t.connectorRef] = t.id;
+        }
+      }
+      setSwSelectedSchemas(importedIds);
+      setSwSchemaToTypeId(refToId);
+    } catch (err) {
+      console.error("Schema discovery failed:", err);
+    } finally {
+      setSwSchemasLoading(false);
+    }
+  };
+
+  const handleSwImportSchemas = async () => {
+    if (!customerId || !projectId || swSelectedSchemas.size === 0) return;
+    setSwImporting(true);
+    try {
+      const result = await importConnectorSchemas(customerId, projectId, Array.from(swSelectedSchemas));
+      alert(`${result.types?.length ?? 0} Content Types importiert`);
+      setSwSchemas([]);
+    } catch (err) {
+      console.error("Schema import failed:", err);
+      alert("Import fehlgeschlagen");
+    } finally {
+      setSwImporting(false);
+    }
   };
 
   if (projectLoading) {
@@ -338,6 +457,265 @@ function ConnectorsPageContent() {
             </Button>
           )}
         </div>
+
+        {/* Shopware Configuration */}
+        {connector.id === "shopware" && (
+          <div className="flex gap-8">
+            {/* Left: Form */}
+            <div className="flex-1 max-w-lg space-y-6">
+              <div>
+                <h2 className="text-lg font-semibold">Connection</h2>
+                <p className="text-sm text-muted-foreground">Shopware 6 Admin API credentials</p>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Shop URL</Label>
+                  <Input
+                    value={swShopUrl}
+                    onChange={(e) => setSwShopUrl(e.target.value)}
+                    placeholder="https://my-shop.com"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Client ID</Label>
+                  <Input
+                    value={swClientId}
+                    onChange={(e) => setSwClientId(e.target.value)}
+                    placeholder="Integration Client ID"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Client Secret</Label>
+                  <Input
+                    type="password"
+                    value={swClientSecret}
+                    onChange={(e) => setSwClientSecret(e.target.value)}
+                    placeholder="Integration Client Secret"
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="outline"
+                  onClick={handleSwTest}
+                  disabled={swTestStatus === "testing" || !swShopUrl || !swClientId || !swClientSecret}
+                >
+                  {swTestStatus === "testing" && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {swTestStatus === "success" && <Check className="mr-2 h-4 w-4 text-green-600" />}
+                  {swTestStatus === "error" && <AlertCircle className="mr-2 h-4 w-4 text-destructive" />}
+                  Test Connection
+                </Button>
+                <SaveButton status={swSaveStatus} onClick={handleSwSave} />
+              </div>
+
+              {swTestStatus === "success" && (
+                <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950">
+                  <Check className="h-4 w-4 text-green-600 shrink-0" />
+                  <p className="text-sm text-green-800 dark:text-green-300">
+                    Connected{swTestShopName ? ` — ${swTestShopName}` : ""}
+                  </p>
+                </div>
+              )}
+
+              {swTestStatus === "error" && (
+                <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950">
+                  <AlertCircle className="h-4 w-4 text-red-600 shrink-0" />
+                  <p className="text-sm text-red-800 dark:text-red-300">{swTestError}</p>
+                </div>
+              )}
+
+              {/* Use as Source */}
+              {isSwConnected && (
+                <div className="border-t pt-6">
+                  <label className="flex items-center justify-between gap-4 rounded-lg border p-4 cursor-pointer hover:bg-muted/50 transition-colors">
+                    <div>
+                      <p className="text-sm font-medium">Use as Source</p>
+                      <p className="text-xs text-muted-foreground">
+                        Make Shopware content (products, categories) available as input sources in Flows
+                      </p>
+                    </div>
+                    <input
+                      type="checkbox"
+                      checked={swAsSource}
+                      onChange={async (e) => {
+                        setSwAsSource(e.target.checked);
+                        if (customerId && projectId) {
+                          await updateProject(customerId, projectId, {
+                            connector: {
+                              type: "shopware",
+                              useAsSource: e.target.checked,
+                              shopware: {
+                                shopUrl: swShopUrl.replace(/\/+$/, ""),
+                                clientId: swClientId,
+                                clientSecret: swClientSecret,
+                              },
+                            },
+                          });
+                          await refreshProjects();
+                        }
+                      }}
+                      className="h-4 w-4 rounded border-gray-300"
+                    />
+                  </label>
+                </div>
+              )}
+
+              {/* Schema Discovery */}
+              {isSwConnected && (
+                <div className="border-t pt-6 space-y-4">
+                  <div>
+                    <h2 className="text-lg font-semibold">CMS Layouts</h2>
+                    <p className="text-sm text-muted-foreground">
+                      Import Shopping Experiences from Shopware as Content Types
+                    </p>
+                  </div>
+
+                  {swSchemasLoading ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Loading layouts...
+                    </div>
+                  ) : swSchemas.length > 0 ? (
+                    <div className="space-y-3">
+                      <div className="rounded-lg border divide-y max-h-[400px] overflow-y-auto">
+                        {swSchemas.map((schema) => {
+                          const slots = schema.slots as Array<{ id: string; label: string; type: string }>;
+                          const isExpanded = swExpandedSchema === schema.id;
+                          const isImported = swSelectedSchemas.has(schema.id);
+                          return (
+                            <div key={schema.id}>
+                              <div className="flex items-center gap-2 px-3 py-2.5 hover:bg-muted/50">
+                                <button
+                                  type="button"
+                                  onClick={() => setSwExpandedSchema(isExpanded ? null : schema.id)}
+                                  className="flex-1 flex items-center gap-2 min-w-0 text-left"
+                                >
+                                  <ChevronDown className={`h-3.5 w-3.5 text-muted-foreground transition-transform shrink-0 ${isExpanded ? "rotate-180" : "-rotate-90"}`} />
+                                  <span className="text-sm font-medium truncate">{schema.label}</span>
+                                  <Badge variant="secondary" className="text-[10px] shrink-0 ml-auto">
+                                    {slots.length}
+                                  </Badge>
+                                </button>
+                                {isImported ? (
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 text-xs text-destructive hover:text-destructive shrink-0"
+                                    onClick={async () => {
+                                      if (!customerId || !projectId) return;
+                                      const typeId = swSchemaToTypeId[schema.id];
+                                      if (!typeId) return;
+                                      try {
+                                        const { deleteContentType } = await import("@/lib/api");
+                                        await deleteContentType(customerId, projectId, typeId);
+                                        const next = new Set(swSelectedSchemas);
+                                        next.delete(schema.id);
+                                        setSwSelectedSchemas(next);
+                                        const nextMap = { ...swSchemaToTypeId };
+                                        delete nextMap[schema.id];
+                                        setSwSchemaToTypeId(nextMap);
+                                      } catch { /* ignore */ }
+                                    }}
+                                  >
+                                    Remove
+                                  </Button>
+                                ) : (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-7 text-xs shrink-0"
+                                    onClick={async () => {
+                                      if (!customerId || !projectId) return;
+                                      try {
+                                        const result = await importConnectorSchemas(customerId, projectId, [schema.id]);
+                                        const next = new Set(swSelectedSchemas);
+                                        next.add(schema.id);
+                                        setSwSelectedSchemas(next);
+                                        // Track the created type ID for later removal
+                                        if (result.types?.[0]) {
+                                          setSwSchemaToTypeId((prev) => ({
+                                            ...prev,
+                                            [schema.id]: (result.types[0] as { id: string }).id,
+                                          }));
+                                        }
+                                      } catch { /* ignore */ }
+                                    }}
+                                  >
+                                    Import
+                                  </Button>
+                                )}
+                              </div>
+                              {isExpanded && slots.length > 0 && (
+                                <div className="px-3 pb-2 pl-9">
+                                  <div className="rounded border bg-muted/30 divide-y">
+                                    {slots.map((slot, idx) => (
+                                      <div key={`${slot.id}-${idx}`} className="flex items-center gap-2 px-3 py-1.5 text-xs">
+                                        <Badge variant="outline" className="text-[10px] px-1.5 h-4 shrink-0">
+                                          {slot.type}
+                                        </Badge>
+                                        <span className="text-muted-foreground truncate">{slot.label}</span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{swSelectedSchemas.size} imported</span>
+                        <span>&middot;</span>
+                        <button type="button" onClick={handleSwLoadSchemas} className="hover:text-foreground transition-colors">
+                          Refresh
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      onClick={handleSwLoadSchemas}
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      Load Schemas
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Right: Setup Guide */}
+            <div className="w-80 shrink-0">
+              <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950 sticky top-8">
+                <div className="flex gap-2 mb-3">
+                  <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+                  <p className="text-sm font-medium text-blue-800 dark:text-blue-300">Shopware Setup</p>
+                </div>
+                <div className="text-xs text-blue-800 dark:text-blue-300 space-y-3">
+                  <div>
+                    <p className="font-medium">1. Create Role</p>
+                    <p className="opacity-80 mt-0.5">Settings &rarr; System &rarr; Users & Permissions &rarr; Roles &rarr; New Role &quot;FlowBoost&quot;</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Permissions:</p>
+                    <ul className="list-disc ml-4 mt-1 space-y-0.5 opacity-90">
+                      <li>Catalogues &rarr; Categories: View, Edit, Create</li>
+                      <li>Content &rarr; Shopping Experiences: View</li>
+                      <li>Catalogues &rarr; Products: View</li>
+                      <li>Content &rarr; Media: View, Create</li>
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="font-medium">2. Create Integration</p>
+                    <p className="opacity-80 mt-0.5">Settings &rarr; System &rarr; Integrations &rarr; Add Integration &rarr; Assign role &quot;FlowBoost&quot;</p>
+                  </div>
+                  <p className="opacity-70 border-t border-blue-200 dark:border-blue-800 pt-2 mt-2">Client Secret is shown only once. No admin access required.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Git Repository Configuration */}
         {connector.id === "git" && isGitConnected && (
@@ -535,17 +913,19 @@ function ConnectorsPageContent() {
 
                         {/* Status / Action */}
                         <div className="flex items-center gap-2 shrink-0">
-                          {connector.id === "git" && status === "connected" ? (
+                          {status === "connected" ? (
                             <>
-                              <Button variant="ghost" size="sm" className="text-xs h-8" asChild>
-                                <Link href="/website">View Index</Link>
-                              </Button>
+                              {connector.id === "git" && (
+                                <Button variant="ghost" size="sm" className="text-xs h-8" asChild>
+                                  <Link href="/website">View Index</Link>
+                                </Button>
+                              )}
                               <span className="text-sm font-medium text-green-600">Connected</span>
                               <Button
                                 variant="outline"
                                 size="icon"
                                 className="h-8 w-8"
-                                onClick={() => setDetailView("git")}
+                                onClick={() => setDetailView(connector.id)}
                               >
                                 <Settings className="h-3.5 w-3.5" />
                               </Button>
@@ -560,6 +940,16 @@ function ConnectorsPageContent() {
                             >
                               Connect
                             </Button>
+                          ) : connector.id === "shopware" && status === "not_connected" ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setDetailView("shopware")}
+                            >
+                              Connect
+                            </Button>
+                          ) : status === "coming_soon" ? (
+                            <Badge variant="secondary" className="text-xs font-normal">Coming Soon</Badge>
                           ) : (
                             <Badge variant="secondary" className="text-xs font-normal">Coming Soon</Badge>
                           )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -382,15 +382,6 @@ export function deleteContentType(
   });
 }
 
-export function importConnectorSchemas(
-  customerId: string,
-  projectId: string,
-): Promise<{ message: string; types: ContentTypeDefinition[] }> {
-  return fetchJson(`/customers/${customerId}/projects/${projectId}/content-types/import`, {
-    method: "POST",
-  });
-}
-
 // ── Pipeline ──────────────────────────────────────────────────────
 
 export function getPipelineRuns(customerId: string, projectId: string): Promise<PipelineRun[]> {
@@ -817,4 +808,59 @@ export function removeMediaUsage(
   return fetchJson(`/customers/${customerId}/projects/${projectId}/media/${assetId}/usage/${contentId}`, {
     method: "DELETE",
   });
+}
+
+// ── Connectors ───────────────────────────────────────────────────
+
+export function testConnector(
+  customerId: string,
+  projectId: string,
+  data: { type: string; config: Record<string, string | undefined> },
+): Promise<{ success: boolean; error?: string; shopName?: string }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/test`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function getConnectorSchemas(
+  customerId: string,
+  projectId: string,
+): Promise<{ schemas: Array<{ id: string; label: string; description: string; slots: unknown[] }> }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/schemas`);
+}
+
+export function importConnectorSchemas(
+  customerId: string,
+  projectId: string,
+  schemaIds?: string[],
+): Promise<{ types: Array<{ id: string; label: string }> }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/content-types/import`, {
+    method: "POST",
+    body: JSON.stringify(schemaIds ? { schemaIds } : {}),
+  });
+}
+
+export function browseConnector(
+  customerId: string,
+  projectId: string,
+  query: { entity?: string; search?: string; categoryId?: string; page?: number; limit?: number },
+): Promise<{ total: number; items: Array<{ id: string; name: string; productNumber?: string; description?: string }> }> {
+  const params = new URLSearchParams();
+  if (query.entity) params.set("entity", query.entity);
+  if (query.search) params.set("search", query.search);
+  if (query.categoryId) params.set("categoryId", query.categoryId);
+  if (query.page) params.set("page", String(query.page));
+  if (query.limit) params.set("limit", String(query.limit));
+  const qs = params.toString();
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/browse${qs ? `?${qs}` : ""}`);
+}
+
+export function browseConnectorDetail(
+  customerId: string,
+  projectId: string,
+  refId: string,
+  entity = "products",
+): Promise<{ id: string; name: string; structuredText: string; imageUrl?: string }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/browse/${refId}?entity=${entity}`);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -216,6 +216,7 @@ export interface Competitor {
 
 export interface ConnectorConfig {
   type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "api";
+  useAsSource?: boolean;
   git?: {
     repoUrl: string;
     branch: string;
@@ -235,6 +236,11 @@ export interface ConnectorConfig {
   };
   filesystem?: {
     outputDir: string;
+  };
+  shopware?: {
+    shopUrl: string;
+    clientId: string;
+    clientSecret: string;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Connector Config UI**: Shopware 6 in connector list, config form (Shop URL, Client ID, Client Secret), test connection with OAuth2 validation, two-column layout with setup guide (roles + permissions)
- **Schema Discovery**: Discover CMS layouts (Shopping Experiences) from Shopware Admin API via `POST /search/cms-page`, expandable slot details per layout, individual import/remove per schema
- **Browse API**: Product search (`POST /search/product`) and category listing for future Flow source integration, with Shopware-optimized filters (active only, no variants, `includes` for performance)
- **Use as Source toggle**: `useAsSource` flag on ConnectorConfig, persisted in project settings, prepares connector for bidirectional use (delivery target + flow input source)
- **Schema import filter**: `POST /content-types/import` now accepts optional `schemaIds` array to import selected schemas only
- **Project instructions**: CLAUDE.md added (English only, always `--build` for Docker), added to .gitignore

## Files

- `backend/src/api/routes/connectors.ts` -- NEW (test, schemas, browse, browse/:refId)
- `backend/src/api/server.ts` -- route registered
- `backend/src/api/routes/content-types.ts` -- schemaIds filter on import
- `backend/src/connectors/site/shopware.ts` -- public apiPost(), POST-based schema discovery
- `backend/src/models/types.ts` -- useAsSource on ConnectorConfig
- `frontend/src/app/connectors/page.tsx` -- Shopware config + schema discovery UI
- `frontend/src/lib/api.ts` -- testConnector, getConnectorSchemas, importConnectorSchemas, browseConnector
- `frontend/src/lib/types.ts` -- shopware + useAsSource on ConnectorConfig

## Test Plan

- [ ] Configure Shopware connector (URL, credentials)
- [ ] Test connection -- success/error feedback
- [ ] Load CMS layouts -- slots shown with correct count
- [ ] Expand layout -- slot types and labels visible
- [ ] Import single schema -- appears as content type
- [ ] Remove imported schema -- content type deleted
- [ ] Use as Source toggle -- persists in project config
- [ ] TypeScript compiles (backend + frontend)