### PR TITLE
feat(connector): Listmonk newsletter connector

### DIFF
--- a/backend/src/api/routes/connectors.ts
+++ b/backend/src/api/routes/connectors.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { createLogger } from "../../utils/logger.js";
 import { ShopwareSiteConnector } from "../../connectors/site/shopware.js";
 import { createSiteConnector } from "../../connectors/site/factory.js";
+import { ListmonkConnector } from "../../connectors/email/listmonk.js";
 
 const log = createLogger("api:connectors");
 
@@ -11,11 +12,7 @@ export async function connectorRoutes(app: FastifyInstance) {
     Params: { customerId: string; projectId: string };
     Body: {
       type: string;
-      config: {
-        shopUrl?: string;
-        clientId?: string;
-        clientSecret?: string;
-      };
+      config: Record<string, string | undefined>;
     };
   }>("/test", async (request, reply) => {
     const { type, config } = request.body;
@@ -75,7 +72,22 @@ export async function connectorRoutes(app: FastifyInstance) {
       }
     }
 
-    return reply.status(400).send({ success: false, error: `Connector-Typ "${type}" wird nicht unterstützt` });
+    if (type === "listmonk") {
+      if (!config.baseUrl || !config.username || !config.password) {
+        return reply.status(400).send({ success: false, error: "baseUrl, username, password are required" });
+      }
+
+      const connector = new ListmonkConnector({
+        baseUrl: (config.baseUrl as string).replace(/\/+$/, ""),
+        username: config.username as string,
+        password: config.password as string,
+      });
+
+      const result = await connector.testConnection();
+      return result;
+    }
+
+    return reply.status(400).send({ success: false, error: `Connector type "${type}" not supported` });
   });
 
   // GET /connectors/schemas — discover schemas from configured connector
@@ -190,6 +202,50 @@ export async function connectorRoutes(app: FastifyInstance) {
       log.error({ err, refId, entity }, "connector browse detail failed");
       return reply.status(500).send({ error: message });
     }
+  });
+
+  // GET /connectors/templates — list templates from email connector (Listmonk)
+  app.get<{
+    Params: { customerId: string; projectId: string };
+  }>("/templates", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const projects = app.ctx.projectsFor(customerId);
+    const project = projects.get(projectId);
+    if (!project) return reply.status(404).send({ error: "Project not found" });
+
+    if (project.connector?.type === "listmonk") {
+      const lm = project.connector.listmonk;
+      if (!lm?.baseUrl || !lm?.username || !lm?.password) {
+        return reply.status(400).send({ error: "Listmonk connector not configured" });
+      }
+      const connector = new ListmonkConnector(lm);
+      const templates = await connector.getTemplates();
+      return { templates };
+    }
+
+    return reply.status(400).send({ error: "No email connector configured" });
+  });
+
+  // GET /connectors/lists — list subscriber lists from email connector (Listmonk)
+  app.get<{
+    Params: { customerId: string; projectId: string };
+  }>("/lists", async (request, reply) => {
+    const { customerId, projectId } = request.params;
+    const projects = app.ctx.projectsFor(customerId);
+    const project = projects.get(projectId);
+    if (!project) return reply.status(404).send({ error: "Project not found" });
+
+    if (project.connector?.type === "listmonk") {
+      const lm = project.connector.listmonk;
+      if (!lm?.baseUrl || !lm?.username || !lm?.password) {
+        return reply.status(400).send({ error: "Listmonk connector not configured" });
+      }
+      const connector = new ListmonkConnector(lm);
+      const lists = await connector.getLists();
+      return { lists };
+    }
+
+    return reply.status(400).send({ error: "No email connector configured" });
   });
 }
 

--- a/backend/src/connectors/email/listmonk.ts
+++ b/backend/src/connectors/email/listmonk.ts
@@ -1,0 +1,169 @@
+import { createLogger } from "../../utils/logger.js";
+
+const log = createLogger("connector:listmonk");
+
+export interface ListmonkConfig {
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
+export interface ListmonkTemplate {
+  id: number;
+  name: string;
+  type: string;       // "campaign" | "tx"
+  isDefault: boolean;
+}
+
+export interface ListmonkList {
+  id: number;
+  name: string;
+  type: string;       // "public" | "private"
+  optin: string;      // "single" | "double"
+  subscriberCount: number;
+  tags: string[];
+}
+
+export interface CreateDraftPayload {
+  name: string;           // internal campaign name
+  subject: string;        // email subject line
+  body: string;           // HTML content
+  listIds: number[];      // recipient list IDs
+  templateId?: number;    // Listmonk template ID
+  fromEmail?: string;     // sender email
+  tags?: string[];
+}
+
+export interface CreateDraftResult {
+  id: number;
+  url: string;
+  status: string;
+}
+
+export class ListmonkConnector {
+  readonly platform = "listmonk";
+
+  constructor(private config: ListmonkConfig) {}
+
+  // ── Auth ──────────────────────────────────────────────────
+
+  private authHeader(): string {
+    const encoded = Buffer.from(`${this.config.username}:${this.config.password}`).toString("base64");
+    return `Basic ${encoded}`;
+  }
+
+  // ── API Helpers ───────────────────────────────────────────
+
+  private async apiGet<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.config.baseUrl}/api${path}`, {
+      headers: {
+        Authorization: this.authHeader(),
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) throw new Error(`Listmonk API GET ${path}: ${res.status}`);
+    return res.json() as Promise<T>;
+  }
+
+  private async apiPost<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${this.config.baseUrl}/api${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: this.authHeader(),
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Listmonk API POST ${path}: ${res.status} ${text}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  // ── Public API ────────────────────────────────────────────
+
+  async testConnection(): Promise<{ success: boolean; listCount?: number; error?: string }> {
+    try {
+      const result = await this.apiGet<{ data: { results: unknown[]; total: number } }>("/lists?per_page=1");
+      const listCount = result.data?.total ?? 0;
+      log.info({ baseUrl: this.config.baseUrl, listCount }, "Listmonk connection test successful");
+      return { success: true, listCount };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Connection failed";
+      log.warn({ err, baseUrl: this.config.baseUrl }, "Listmonk connection test failed");
+      return { success: false, error: message };
+    }
+  }
+
+  async getTemplates(): Promise<ListmonkTemplate[]> {
+    const result = await this.apiGet<{
+      data: Array<{
+        id: number;
+        name: string;
+        type: string;
+        is_default: boolean;
+      }>;
+    }>("/templates");
+
+    return (result.data ?? [])
+      .filter((t) => t.type === "campaign")
+      .map((t) => ({
+        id: t.id,
+        name: t.name,
+        type: t.type,
+        isDefault: t.is_default,
+      }));
+  }
+
+  async getLists(): Promise<ListmonkList[]> {
+    const result = await this.apiGet<{
+      data: {
+        results: Array<{
+          id: number;
+          name: string;
+          type: string;
+          optin: string;
+          subscriber_count: number;
+          tags: string[];
+        }>;
+      };
+    }>("/lists?per_page=100");
+
+    return (result.data?.results ?? []).map((l) => ({
+      id: l.id,
+      name: l.name,
+      type: l.type,
+      optin: l.optin,
+      subscriberCount: l.subscriber_count,
+      tags: l.tags ?? [],
+    }));
+  }
+
+  async createDraft(payload: CreateDraftPayload): Promise<CreateDraftResult> {
+    const result = await this.apiPost<{ data: { id: number; status: string } }>("/campaigns", {
+      name: payload.name,
+      subject: payload.subject,
+      body: payload.body,
+      content_type: "html",
+      lists: payload.listIds,
+      type: "regular",
+      status: "draft",
+      template_id: payload.templateId,
+      from_email: payload.fromEmail,
+      tags: payload.tags ?? ["flowboost"],
+    });
+
+    const campaignId = result.data.id;
+    const url = `${this.config.baseUrl}/campaigns/${campaignId}`;
+
+    log.info({ campaignId, subject: payload.subject, lists: payload.listIds }, "Listmonk campaign draft created");
+
+    return {
+      id: campaignId,
+      url,
+      status: result.data.status,
+    };
+  }
+}

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -81,7 +81,7 @@ export interface Competitor {
 }
 
 export interface ConnectorConfig {
-  type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "api";
+  type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "listmonk" | "api";
   useAsSource?: boolean;
   git?: {
     repoUrl: string;
@@ -109,6 +109,11 @@ export interface ConnectorConfig {
     siteUrl: string;
     username: string;
     applicationPassword: string;
+  };
+  listmonk?: {
+    baseUrl: string;
+    username: string;
+    password: string;
   };
 }
 

--- a/frontend/src/app/connectors/page.tsx
+++ b/frontend/src/app/connectors/page.tsx
@@ -52,7 +52,7 @@ import {
 // ── Types ────────────────────────────────────────────────────────
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
-type ConnectorCategory = "site" | "ecommerce" | "social" | "media";
+type ConnectorCategory = "site" | "ecommerce" | "newsletter" | "social" | "media";
 type Framework = "astro" | "hugo" | "nextjs" | "custom";
 
 interface ConnectorDef {
@@ -89,6 +89,8 @@ const CONNECTORS: ConnectorDef[] = [
   { id: "shopware", name: "Shopware 6", category: "ecommerce", icon: ShoppingBag, description: "Read Shopping Experiences, write CMS slots", comingSoon: false },
   { id: "shopify", name: "Shopify", category: "ecommerce", icon: ShoppingBag, description: "Publish to Shopify blog and pages", comingSoon: true },
   { id: "woocommerce", name: "WooCommerce", category: "ecommerce", icon: ShoppingBag, description: "Publish via WooCommerce REST API", comingSoon: true },
+  { id: "listmonk", name: "Listmonk", category: "newsletter", icon: Radio, description: "Create newsletter drafts via Listmonk API", comingSoon: false },
+  { id: "mailchimp", name: "Mailchimp", category: "newsletter", icon: Radio, description: "Create campaigns via Mailchimp API", comingSoon: true },
   { id: "linkedin", name: "LinkedIn", category: "social", icon: Linkedin, description: "Post to LinkedIn", comingSoon: true },
   { id: "instagram", name: "Instagram", category: "social", icon: Instagram, description: "Post to Instagram", comingSoon: true },
   { id: "tiktok", name: "TikTok", category: "social", icon: Music2, description: "Post to TikTok", comingSoon: true },
@@ -100,6 +102,7 @@ const CONNECTORS: ConnectorDef[] = [
 const CATEGORY_LABELS: Record<ConnectorCategory, { title: string; description: string }> = {
   site: { title: "Site Delivery", description: "Publish articles, guides, and landing pages" },
   ecommerce: { title: "E-Commerce", description: "Connect shop platforms for content and product data" },
+  newsletter: { title: "Newsletter", description: "Create and send email campaigns" },
   social: { title: "Social Channels", description: "Distribute social media posts" },
   media: { title: "Media Platforms", description: "Upload video and audio content" },
 };
@@ -171,6 +174,18 @@ function ConnectorsPageContent() {
   // Map: connectorRef (schema.id) → content type ID (slug) for delete
   const [swSchemaToTypeId, setSwSchemaToTypeId] = useState<Record<string, string>>({});
 
+  // Listmonk connector state
+  const [lmBaseUrl, setLmBaseUrl] = useState("");
+  const [lmUsername, setLmUsername] = useState("");
+  const [lmPassword, setLmPassword] = useState("");
+  const [lmTestStatus, setLmTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
+  const [lmTestError, setLmTestError] = useState("");
+  const [lmListCount, setLmListCount] = useState(0);
+  const [lmSaveStatus, setLmSaveStatus] = useState<SaveStatus>("idle");
+  const [lmTemplates, setLmTemplates] = useState<Array<{ id: number; name: string; isDefault: boolean }>>([]);
+  const [lmLists, setLmLists] = useState<Array<{ id: number; name: string; type: string; subscriberCount: number }>>([]);
+  const [lmDataLoading, setLmDataLoading] = useState(false);
+
   const loadGhRepos = useCallback(async (installationId: number) => {
     setGhLoadingRepos(true);
     try {
@@ -211,6 +226,12 @@ function ConnectorsPageContent() {
       setGhAssetsPath(project.connector.github.assetsPath);
       setGhCategoriesPath(project.connector.github.categoriesPath ?? "src/data/categories.json");
       setGhAuthorsPath(project.connector.github.authorsPath ?? "src/data/authors.json");
+    }
+    // Load Listmonk config
+    if (project.connector?.listmonk) {
+      setLmBaseUrl(project.connector.listmonk.baseUrl ?? "");
+      setLmUsername(project.connector.listmonk.username ?? "");
+      setLmPassword(project.connector.listmonk.password ?? "");
     }
     // Load Shopware config
     if (project.connector?.shopware) {
@@ -314,7 +335,74 @@ function ConnectorsPageContent() {
   const isGitConnected = connectorType === "github" && !!ghInstallationId;
 
   const isSwConnected = (project?.connector?.type === "shopware" && !!project?.connector?.shopware?.shopUrl)
+    || (swTestStatus === "success")
     || (swSaveStatus === "saved" && !!swShopUrl && !!swClientId && !!swClientSecret);
+
+  const isLmConnected = (project?.connector?.type === "listmonk" && !!project?.connector?.listmonk?.baseUrl)
+    || (lmTestStatus === "success")
+    || (lmSaveStatus === "saved" && !!lmBaseUrl && !!lmUsername && !!lmPassword);
+
+  const handleLmTest = async () => {
+    if (!lmBaseUrl || !lmUsername || !lmPassword) return;
+    setLmTestStatus("testing");
+    setLmTestError("");
+    try {
+      const result = await testConnector(customerId, projectId, {
+        type: "listmonk",
+        config: { baseUrl: lmBaseUrl.replace(/\/+$/, ""), username: lmUsername, password: lmPassword },
+      });
+      if (result.success) {
+        setLmTestStatus("success");
+        setLmListCount((result as { listCount?: number }).listCount ?? 0);
+      } else {
+        setLmTestStatus("error");
+        setLmTestError(result.error ?? "Unknown error");
+      }
+    } catch (err) {
+      setLmTestStatus("error");
+      setLmTestError(err instanceof Error ? err.message : "Connection failed");
+    }
+  };
+
+  const handleLmSave = () => withSave(setLmSaveStatus, async () => {
+    await updateProject(customerId, projectId, {
+      connector: {
+        type: "listmonk",
+        listmonk: {
+          baseUrl: lmBaseUrl.replace(/\/+$/, ""),
+          username: lmUsername,
+          password: lmPassword,
+        },
+      },
+    });
+    await refreshProjects();
+  });
+
+  const handleLmLoadData = async () => {
+    if (!customerId || !projectId) return;
+    setLmDataLoading(true);
+    try {
+      const [templatesRes, listsRes] = await Promise.all([
+        import("@/lib/api").then((m) => m.getConnectorTemplates(customerId, projectId)),
+        import("@/lib/api").then((m) => m.getConnectorLists(customerId, projectId)),
+      ]);
+      setLmTemplates(templatesRes.templates);
+      setLmLists(listsRes.lists);
+    } catch (err) {
+      console.error("Failed to load Listmonk data:", err);
+    } finally {
+      setLmDataLoading(false);
+    }
+  };
+
+  // Auto-load Listmonk data when entering detail view (with connected project)
+  useEffect(() => {
+    if (detailView === "listmonk" && isLmConnected && lmTemplates.length === 0 && !lmDataLoading && customerId && projectId
+        && project?.connector?.type === "listmonk") {
+      handleLmLoadData();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailView, isLmConnected, project?.connector?.type]);
 
   // Auto-load schemas when entering Shopware detail view
   useEffect(() => {
@@ -327,6 +415,7 @@ function ConnectorsPageContent() {
   const getConnectorStatus = (id: string): "connected" | "not_connected" | "coming_soon" => {
     if (id === "git" && isGitConnected) return "connected";
     if (id === "shopware" && isSwConnected) return "connected";
+    if (id === "listmonk" && isLmConnected) return "connected";
     const def = CONNECTORS.find((c) => c.id === id);
     if (def?.comingSoon) return "coming_soon";
     return "not_connected";
@@ -460,6 +549,135 @@ function ConnectorsPageContent() {
             </Button>
           )}
         </div>
+
+        {/* Listmonk Configuration */}
+        {connector.id === "listmonk" && (
+          <div className="flex gap-8">
+            <div className="flex-1 max-w-lg space-y-6">
+              <div>
+                <h2 className="text-lg font-semibold">Connection</h2>
+                <p className="text-sm text-muted-foreground">Listmonk API credentials</p>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Listmonk URL</Label>
+                  <Input value={lmBaseUrl} onChange={(e) => setLmBaseUrl(e.target.value)} placeholder="https://newsletter.example.com" />
+                </div>
+                <div className="space-y-2">
+                  <Label>Username</Label>
+                  <Input value={lmUsername} onChange={(e) => setLmUsername(e.target.value)} placeholder="API username" />
+                </div>
+                <div className="space-y-2">
+                  <Label>Password / API Token</Label>
+                  <Input type="password" value={lmPassword} onChange={(e) => setLmPassword(e.target.value)} placeholder="API token or password" />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Button variant="outline" onClick={handleLmTest} disabled={lmTestStatus === "testing" || !lmBaseUrl || !lmUsername || !lmPassword}>
+                  {lmTestStatus === "testing" && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {lmTestStatus === "success" && <Check className="mr-2 h-4 w-4 text-green-600" />}
+                  {lmTestStatus === "error" && <AlertCircle className="mr-2 h-4 w-4 text-destructive" />}
+                  Test Connection
+                </Button>
+                <SaveButton status={lmSaveStatus} onClick={handleLmSave} />
+              </div>
+
+              {lmTestStatus === "success" && (
+                <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950">
+                  <Check className="h-4 w-4 text-green-600 shrink-0" />
+                  <p className="text-sm text-green-800 dark:text-green-300">
+                    Connected — {lmListCount} list{lmListCount !== 1 ? "s" : ""} found
+                  </p>
+                </div>
+              )}
+
+              {lmTestStatus === "error" && (
+                <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950">
+                  <AlertCircle className="h-4 w-4 text-red-600 shrink-0" />
+                  <p className="text-sm text-red-800 dark:text-red-300">{lmTestError}</p>
+                </div>
+              )}
+
+              {/* Templates + Lists */}
+              {isLmConnected && (
+                <div className="border-t pt-6 space-y-4">
+                  {lmDataLoading ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Loading templates and lists...
+                    </div>
+                  ) : (
+                    <>
+                      {lmTemplates.length > 0 && (
+                        <div>
+                          <h3 className="text-sm font-semibold mb-2">Templates</h3>
+                          <div className="rounded-lg border divide-y">
+                            {lmTemplates.map((t) => (
+                              <div key={t.id} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+                                <span className="flex-1">{t.name}</span>
+                                {t.isDefault && <Badge variant="secondary" className="text-[10px]">Default</Badge>}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {lmLists.length > 0 && (
+                        <div>
+                          <h3 className="text-sm font-semibold mb-2">Subscriber Lists</h3>
+                          <div className="rounded-lg border divide-y">
+                            {lmLists.map((l) => (
+                              <div key={l.id} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+                                <span className="flex-1">{l.name}</span>
+                                <Badge variant="outline" className="text-[10px]">{l.type}</Badge>
+                                <span className="text-xs text-muted-foreground">{l.subscriberCount.toLocaleString()} subscribers</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      <button type="button" onClick={handleLmLoadData} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+                        Refresh
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Right: Setup Guide */}
+            <div className="w-80 shrink-0">
+              <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950 sticky top-8">
+                <div className="flex gap-2 mb-3">
+                  <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+                  <p className="text-sm font-medium text-blue-800 dark:text-blue-300">Listmonk Setup</p>
+                </div>
+                <div className="text-xs text-blue-800 dark:text-blue-300 space-y-3">
+                  <div>
+                    <p className="font-medium">1. Create Role</p>
+                    <p className="opacity-80 mt-0.5">Settings &rarr; User Roles &rarr; New &rarr; Name: &quot;FlowBoost&quot;</p>
+                    <ul className="list-disc ml-4 mt-1 space-y-0.5 opacity-90">
+                      <li>Lists: <code className="bg-blue-100 dark:bg-blue-900 px-1 rounded">lists:get_all</code></li>
+                      <li>Campaigns: <code className="bg-blue-100 dark:bg-blue-900 px-1 rounded">campaigns:get</code>, <code className="bg-blue-100 dark:bg-blue-900 px-1 rounded">campaigns:manage</code></li>
+                      <li>Templates: <code className="bg-blue-100 dark:bg-blue-900 px-1 rounded">templates:get</code></li>
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="font-medium">2. Create API User</p>
+                    <p className="opacity-80 mt-0.5">Settings &rarr; Users &rarr; New User &rarr; Type: API &rarr; Role: FlowBoost</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">3. Copy Credentials</p>
+                    <p className="opacity-80 mt-0.5">Username + API token. Token is shown only once.</p>
+                  </div>
+                  <p className="opacity-70 border-t border-blue-200 dark:border-blue-800 pt-2 mt-2">FlowBoost creates campaign drafts only — never sends automatically.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Shopware Configuration */}
         {connector.id === "shopware" && (
@@ -887,7 +1105,7 @@ function ConnectorsPageContent() {
 
         {/* ── Connections Tab ──────────────────────────────────────── */}
         <TabsContent value="connections" className="mt-6 space-y-8">
-          {(["site", "ecommerce", "social", "media"] as ConnectorCategory[]).map((cat) => {
+          {(["site", "ecommerce", "newsletter", "social", "media"] as ConnectorCategory[]).map((cat) => {
             const items = CONNECTORS.filter((c) => c.category === cat);
             return (
               <div key={cat} className="space-y-1">
@@ -943,11 +1161,11 @@ function ConnectorsPageContent() {
                             >
                               Connect
                             </Button>
-                          ) : connector.id === "shopware" && status === "not_connected" ? (
+                          ) : (connector.id === "shopware" || connector.id === "listmonk") && status === "not_connected" ? (
                             <Button
                               variant="outline"
                               size="sm"
-                              onClick={() => setDetailView("shopware")}
+                              onClick={() => setDetailView(connector.id)}
                             >
                               Connect
                             </Button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -864,3 +864,17 @@ export function browseConnectorDetail(
 ): Promise<{ id: string; name: string; structuredText: string; imageUrl?: string }> {
   return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/browse/${refId}?entity=${entity}`);
 }
+
+export function getConnectorTemplates(
+  customerId: string,
+  projectId: string,
+): Promise<{ templates: Array<{ id: number; name: string; type: string; isDefault: boolean }> }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/templates`);
+}
+
+export function getConnectorLists(
+  customerId: string,
+  projectId: string,
+): Promise<{ lists: Array<{ id: number; name: string; type: string; subscriberCount: number }> }> {
+  return fetchJson(`/customers/${customerId}/projects/${projectId}/connectors/lists`);
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -215,7 +215,7 @@ export interface Competitor {
 }
 
 export interface ConnectorConfig {
-  type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "api";
+  type: "git" | "github" | "filesystem" | "shopware" | "wordpress" | "listmonk" | "api";
   useAsSource?: boolean;
   git?: {
     repoUrl: string;
@@ -241,6 +241,11 @@ export interface ConnectorConfig {
     shopUrl: string;
     clientId: string;
     clientSecret: string;
+  };
+  listmonk?: {
+    baseUrl: string;
+    username: string;
+    password: string;
   };
 }
 


### PR DESCRIPTION
## Summary

- **ListmonkConnector** backend class (`backend/src/connectors/email/listmonk.ts`): Basic Auth, testConnection, getTemplates, getLists, createDraft (always `status: "draft"`)
- **Backend routes**: POST `/connectors/test` (Listmonk case), GET `/connectors/templates`, GET `/connectors/lists`
- **Newsletter category** in connector UI with Listmonk (active) + Mailchimp (Coming Soon)
- **Config form**: URL, username, password/token, test connection, setup guide with exact permissions (`lists:get_all`, `campaigns:get`, `campaigns:manage`, `templates:get`)
- **Templates + Lists display**: Auto-loaded when connected, shows template names (default marker) and subscriber lists with count
- **Connected-status fix**: Both Shopware and Listmonk now reliably show "Connected" after save without page reload

Related: #35 (delivery flow — template + list selection TBD)

## Test Plan

- [ ] Configure Listmonk (URL, credentials)
- [ ] Test connection — shows list count
- [ ] Save — "Connected" status appears immediately
- [ ] Templates and subscriber lists displayed
- [ ] Back to All Connectors — status persists without reload
- [ ] TypeScript compiles (backend + frontend)