### PR TITLE
docs: streamline contributing guidelines, vision, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+**What** changed:
+**Why** (problem / motivation):
+
+## Linked Issue
+
+Closes #
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs / chore
+
+## Screenshots
+
+<!-- For UI changes: before/after. Delete if not applicable. -->
+
+## Testing
+
+- [ ] `docker compose up --build` runs
+- [ ] TypeScript passes (`npx tsc --noEmit` in backend + frontend)
+- [ ] Lint passes (`npm run lint` in frontend)
+- [ ] Manually tested the affected feature
+
+## Checklist
+
+- [ ] One focused change (no unrelated changes)
+- [ ] Under ~500 changed lines
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,116 +1,57 @@
 # Contributing to FlowBoost
 
-## Quick Links
-
-- **GitHub:** https://github.com/johrld/flowboost
-- **Issues:** https://github.com/johrld/flowboost/issues
+Thanks for your interest! Here's how to contribute effectively.
 
 ## Maintainers
 
-- **Johannes Herold** — Creator, Architecture, Pipeline
-  - GitHub: [@johrld](https://github.com/johrld)
-
-- **Magnus** — Contributor
-  - GitHub: [@MagnusHL](https://github.com/MagnusHL)
+| Who | Focus | GitHub |
+|---|---|---|
+| Johannes Herold | Project Lead | [@johrld](https://github.com/johrld) |
+| Magnus Hinzke | Media Library, Connectors | [@MagnusHL](https://github.com/MagnusHL) |
 
 ## How to Contribute
 
-1. **Bugs & small fixes** — Open a PR
-2. **New features / architecture changes** — Open an Issue first to discuss
-3. **Refactor-only PRs** — Not accepted unless a maintainer explicitly asks for it
-4. **Questions** — Open a Discussion or Issue
+**Bugs & small fixes** — open a PR directly. Link the issue if one exists.
+
+**Features & architecture changes** — open an Issue first. Describe what, why, and rough scope. Discuss before coding so nobody wastes time on something that doesn't fit.
+
+**Questions & ideas** — open an Issue. Everything is welcome.
 
 ## Before You PR
 
-- Test locally: `docker compose up --build`
-- Run TypeScript check: `cd backend && npx tsc --noEmit` and `cd frontend && npx tsc --noEmit`
-- Run lint: `cd frontend && npm run lint`
-- Keep PRs focused — one thing per PR, don't mix unrelated changes
-- Describe **what** changed and **why**
-- Include screenshots for UI changes (before/after)
+- [ ] Linked Issue exists (features must be discussed first)
+- [ ] Tested locally: `docker compose up --build`
+- [ ] TypeScript passes: `cd backend && npx tsc --noEmit` + `cd frontend && npx tsc --noEmit`
+- [ ] Lint passes: `cd frontend && npm run lint`
+- [ ] One PR = one thing. No unrelated changes mixed in.
+- [ ] Under ~500 changed lines (split larger work into multiple PRs)
+- [ ] Screenshots for UI changes (before/after)
 
-## Development Setup
+## Branching & Commits
 
-```bash
-# 1. Fork and clone
-git clone https://github.com/YOUR_USERNAME/flowboost.git
-cd flowboost
+PRs target `main`. Direct pushes are blocked.
 
-# 2. Run setup (creates .env, configures auth, seeds data)
-bash scripts/setup.sh
+- Branches: `feat/`, `fix/`, `chore/`, `refactor/`
+- Commits: `type(scope): description` — e.g. `feat(pipeline): add retry logic`
 
-# 3. Start services
-docker compose up --build
-```
+## Review
 
-Dashboard: http://localhost:6101 — API: http://localhost:6100
+PRs are reviewed by a maintainer. Questions are part of the process, not rejection. This is a side project — reviews may take a few days.
 
-## Branching
+## AI-Assisted PRs
 
-All PRs go against `main`. No `develop` branch. Direct pushes to `main` are blocked — all changes must go through a PR.
-
-```
-main (protected: no force push, no direct push, PRs required)
-  └── feat/your-feature → PR → main
-```
-
-### Branch Naming
-
-- `feat/` — New features
-- `fix/` — Bug fixes
-- `chore/` — Maintenance, dependencies
-- `refactor/` — Code restructuring
-
-### Commit Format
-
-```
-<type>(<scope>): <description>
-```
-
-Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
-
-Examples:
-- `feat(pipeline): add retry logic for image generation`
-- `fix(sidebar): project selector not updating after create`
-- `chore(docker): update node base image to 22`
-
-## AI-Assisted PRs Welcome
-
-Built with Claude Code, Cursor, Copilot, or other AI tools? Great — just be transparent:
-
-- Note it in the PR description
-- Confirm you understand what the code does
-- Test it locally before submitting
-
-## Project Structure
-
-```
-flowboost/
-├── backend/          # Fastify API + Claude Agent SDK pipeline
-│   ├── src/
-│   │   ├── api/      # REST routes
-│   │   ├── models/   # Data models (JSON file store)
-│   │   ├── pipeline/ # AI agent orchestration
-│   │   └── tools/    # MCP server for agent tools
-│   └── data.seed/    # Seed data + project defaults
-├── frontend/         # Next.js dashboard
-│   └── src/
-│       ├── app/      # Pages (App Router)
-│       ├── components/
-│       └── lib/      # API client, types, context
-└── scripts/          # Setup and utility scripts
-```
+Built with AI tools? Welcome. Just note it in the PR, make sure you understand the code, and test it.
 
 ## What We're Looking For
 
-- Pipeline improvements (new agent prompts, better quality checks)
-- Frontend UX (better empty states, editor improvements)
+- Pipeline improvements (agent prompts, quality checks)
+- Frontend UX (editors, empty states, dashboard)
 - New connectors (WordPress, Webflow, social platforms)
-- Documentation and examples
 - Bug fixes and stability
 
-Check [Issues](https://github.com/johrld/flowboost/issues) for things to work on.
+See [VISION.md](VISION.md) for priorities and scope.
+See [Issues](https://github.com/johrld/flowboost/issues) for open tasks.
 
-## Report a Vulnerability
+## Security
 
-Do not open public issues for security vulnerabilities. Report them via [GitHub Security Advisories](https://github.com/johrld/flowboost/security/advisories/new).
+Report vulnerabilities via [GitHub Security Advisories](https://github.com/johrld/flowboost/security/advisories/new), not public issues.

--- a/README.md
+++ b/README.md
@@ -179,13 +179,12 @@ See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for production setup, authenticatio
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, branching conventions, and PR guidelines.
-
-All PRs go against `main`. AI-assisted contributions are welcome.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [VISION.md](VISION.md) for project direction.
 
 ## Contributors
 
-- [Magnus Hinzke](https://github.com/MagnusHL)
+<a href="https://github.com/johrld"><img src="https://github.com/johrld.png" width="48" height="48" alt="johrld" style="border-radius:50%"></a>
+<a href="https://github.com/MagnusHL"><img src="https://github.com/MagnusHL.png" width="48" height="48" alt="MagnusHL" style="border-radius:50%"></a>
 
 ## License
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,29 @@
+# FlowBoost Vision
+
+FlowBoost turns a single briefing into content for every channel —
+articles, social posts, newsletters — all consistent, all AI-powered, all self-hosted.
+
+## Design Principles
+
+1. **One briefing, many outputs.** Everything starts from a shared context.
+2. **Pipeline over prompt.** Multi-agent pipelines with structured phases, not single prompts.
+3. **Self-hosted first.** No SaaS dependency. Your data, your infrastructure, your API keys.
+4. **Simple over clever.** File-based JSON, Docker Compose, no database. Complexity only when needed.
+5. **Platform-aware.** A LinkedIn post (3,000 chars) is not a tweet (280 chars). Each format has its own constraints.
+
+## Priorities
+
+**Now:** Stability, editor UX, pipeline quality
+
+**Next:** New connectors (Webflow, social APIs), content scheduling, multi-user support
+
+**Later:** Plugin system, video/audio pipelines, external API
+
+## Out of Scope (For Now)
+
+These can change with strong reasoning, but right now:
+
+- **Database migrations** — file-based JSON by design, no Postgres/SQLite
+- **Multi-tenant / SaaS** — self-hosted for individual teams, not a platform
+- **Alternative AI providers** — built on Claude Agent SDK, not adding OpenAI/Gemini for the content pipeline
+- **Standalone refactors** — code style or restructuring belongs inside a fix or feature, not standalone


### PR DESCRIPTION
## Summary
- Simplified CONTRIBUTING.md (122 → 52 lines): less defensive tone, clearer structure
- Simplified VISION.md (83 → 28 lines): compact principles and priorities
- Simplified PR template (45 → 27 lines): removed AI assistance section, fewer checkboxes
- Fixed README: removed duplication with CONTRIBUTING, added both contributors as avatars

## Linked Issue
None — housekeeping

## Type
- [x] Docs / chore