### PR TITLE
feat(shopware): Content-Type-Editor mit TipTap, MediaPicker und Grid-Layout

### DIFF
--- a/backend/data.seed/project-defaults/content-types/shopware-landing-page.json
+++ b/backend/data.seed/project-defaults/content-types/shopware-landing-page.json
@@ -1,0 +1,23 @@
+{
+  "id": "shopware-landing-page",
+  "label": "Shopware Landing Page",
+  "description": "CMS Erlebniswelt landing page for Shopware 6",
+  "category": "site",
+  "source": "builtin",
+  "icon": "shopware",
+  "fields": [],
+  "pipeline": {
+    "mode": "single-phase",
+    "phases": ["write", "image"]
+  },
+  "agent": {
+    "role": "You are a conversion-focused landing page copywriter for Shopware e-commerce. You write persuasive, benefit-driven copy for CMS Erlebniswelt slots. Each slot has a specific purpose — use the exampleContent to understand what belongs where.",
+    "guidelines": "## Slot-Based Content Writing\n\nYou are writing content for Shopware CMS Erlebniswelt slots. The layout structure varies per client — you receive the available slots and must fill each appropriately.\n\n## How to Interpret Slot Names\n\nSlot IDs follow the pattern: s{N}-{blockType}-{slotName}\n\nFrom the block type, slot name, and exampleContent, derive the content purpose:\n- \"hero\" or section 0 → Primary headline, subline, call-to-action\n- \"text-two-column\" → Two complementary content pieces side by side\n- \"text-three-column\" → Three equal pieces (often USPs or features)\n- \"image-text\" → Visual + explanatory text pair\n- \"text\" with \"content\" → Full-width SEO text section\n- \"product-slider\" → Product selection (suggest relevant product IDs)\n- Last section → Typically a CTA (call-to-action with contact options)\n\nIMPORTANT: If a slot has exampleContent, use it to understand the PURPOSE of that slot. Write new content that serves the same purpose but for the new topic.\n\n## Content Rules per Slot Type\n\n### Text Slots (rich-text)\n- Write benefit-driven HTML: headings, paragraphs, lists\n- First section (hero): H1 with primary keyword + main benefit\n- Content sections: H2 + 200-400 words of SEO-optimized text\n- Short paragraphs (max 3-4 sentences)\n- Answer-first format for AI search\n\n### Image Slots\n- Provide a descriptive image generation prompt\n- Include: subject, style, mood, composition\n- No text overlays in images\n\n### Product Slots (json)\n- Suggest products relevant to the page topic\n- Format as product IDs or search criteria\n\n### Multi-Column Slots\n- Each column should cover ONE distinct point\n- Don't repeat the same benefit across columns\n- Columns should be independently readable\n\n## SEO Rules\n- Primary keyword in first text slot (hero/headline)\n- Each text section targets a relevant keyword\n- Internal links to products and categories where natural\n- Meta: 150-160 chars with benefit + CTA\n\n## Do\n- Use exampleContent to understand each slot's purpose\n- Adapt tone and content to the slot's position in the page\n- Write for scan-readers (headings, bold, bullets)\n- Include specific numbers and data where available\n- Reference the client's products/services\n\n## Don't\n- Write generic marketing fluff\n- Ignore the slot context (don't write a hero for a FAQ slot)\n- Write walls of text without structure\n- Repeat content across slots\n- Ignore exampleContent — it tells you what this slot is FOR"
+  },
+  "localization": {
+    "mode": "single",
+    "translateOnGenerate": false
+  },
+  "createdAt": "2026-03-29T00:00:00.000Z",
+  "updatedAt": "2026-03-29T00:00:00.000Z"
+}

--- a/backend/data.seed/project-defaults/templates/shopware-landing-page.md
+++ b/backend/data.seed/project-defaults/templates/shopware-landing-page.md
@@ -1,0 +1,46 @@
+# Shopware Landing Page Template
+
+Reference for writing CMS Erlebniswelt slot content.
+The actual layout structure comes from the imported Shopware layout.
+Each slot has `exampleContent` showing what currently lives there — use it to understand the purpose.
+
+## Slot Type Examples
+
+### Text Slot (Hero / first section)
+Write a compelling H1 headline with the primary keyword.
+Follow with a subline that elaborates the benefit.
+Include a clear call-to-action.
+
+### Text Slot (Content section)
+H2 headline targeting a secondary keyword.
+3-5 paragraphs of benefit-driven content.
+Internal links to relevant products where natural.
+
+### Multi-Column Text Slots
+Each column covers one distinct point.
+Keep columns balanced in length.
+Benefit-focused H3 headlines.
+
+### Image Slot
+Provide a generation prompt describing the desired image.
+Example: "Professional product photography of [topic],
+clean background, editorial style, no text overlays."
+
+### Product Slot
+List relevant product IDs or describe selection criteria.
+Products should match the page topic.
+
+### FAQ Slot (if present)
+8-12 questions users actually ask.
+40-60 word answers each.
+Include primary keyword in at least one question.
+
+## Using exampleContent
+
+Every slot may have `exampleContent` — the current HTML content from the live Shopware page.
+Read it to understand:
+- What TYPE of content this slot displays (headline, features, FAQ, testimonials, CTA)
+- What STRUCTURE the client uses (H1+P, H3 list, accordion, card layout)
+- What TONE the client prefers (formal, casual, technical)
+
+Then write NEW content that serves the same purpose but for the requested topic.

--- a/backend/src/api/routes/content.ts
+++ b/backend/src/api/routes/content.ts
@@ -64,6 +64,7 @@ export async function contentRoutes(app: FastifyInstance) {
     Params: { customerId: string; projectId: string };
     Body: {
       type: ContentType;
+      contentTypeId?: string;
       title: string;
       description?: string;
       category?: string;
@@ -84,6 +85,7 @@ export async function contentRoutes(app: FastifyInstance) {
       customerId,
       projectId,
       type: body.type ?? "article",
+      contentTypeId: body.contentTypeId,
       status: "planned",
       title: body.title ?? "",
       description: body.description,

--- a/backend/src/connectors/site/shopware.ts
+++ b/backend/src/connectors/site/shopware.ts
@@ -204,14 +204,56 @@ export class ShopwareSiteConnector implements SiteConnector {
             else if (slot.type === "product-slider" || slot.type === "product-listing") slotType = "product-list";
             else if (slot.type === "text") slotType = "html";
 
+            // Extract default content from slot config (Ansatz B: content in layout)
+            let defaultContent: string | undefined;
+            const slotConfig = slot.config as Record<string, { source?: string; value?: unknown }> | undefined;
+            if (slotConfig?.content?.value && typeof slotConfig.content.value === "string") {
+              defaultContent = slotConfig.content.value;
+            }
+
             slots.push({
               id: slotId,
               label,
               type: slotType,
-              required: false, // All Shopware slots are optional
+              required: false,
+              exampleContent: defaultContent,
             });
           }
         }
+      }
+
+      // Try to find a category using this layout for real content (Ansatz A: content in slotConfig)
+      try {
+        const catResult = await this.apiPost<{
+          data: Array<{ id: string; slotConfig?: Record<string, Record<string, { source?: string; value?: unknown }>> }>;
+        }>("/search/category", {
+          filter: [{ type: "equals", field: "cmsPageId", value: page.id }],
+          limit: 1,
+          includes: { category: ["id", "slotConfig"] },
+        });
+
+        const category = catResult.data?.[0];
+        if (category?.slotConfig) {
+          // Map slotConfig overrides to our slot IDs
+          for (const slot of slots) {
+            // slotConfig keys are Shopware's internal slot UUIDs, not our s{N}-... IDs
+            // We need to match by position — iterate all slotConfig entries
+            // For now, match by checking if any slotConfig entry has content
+            for (const [, config] of Object.entries(category.slotConfig)) {
+              const content = config?.content?.value;
+              if (content && typeof content === "string" && content.length > 10) {
+                // Heuristic: match slots without exampleContent to available slotConfig entries
+                if (!slot.exampleContent) {
+                  slot.exampleContent = content;
+                  break;
+                }
+              }
+            }
+          }
+          log.info({ layoutId: page.id, categoryId: category.id }, "loaded example content from category slotConfig");
+        }
+      } catch {
+        log.debug({ layoutId: page.id }, "no category found for example content");
       }
 
       schemas.push({
@@ -225,6 +267,7 @@ export class ShopwareSiteConnector implements SiteConnector {
       log.info({ layoutId: page.id, name: page.name, slots: slots.length }, "layout discovered");
     }
 
+    schemas.sort((a, b) => a.label.localeCompare(b.label));
     log.info({ layoutCount: schemas.length }, "Shopware schema discovery complete");
     return schemas;
   }

--- a/backend/src/connectors/site/types.ts
+++ b/backend/src/connectors/site/types.ts
@@ -42,6 +42,8 @@ export interface ConnectorSlot {
     imageAspectRatio?: string;
     maxItems?: number;
   };
+  /** Example content from an existing page using this slot (for AI context) */
+  exampleContent?: string;
 }
 
 // ─── Site Connector Interface ────────────────────────────────

--- a/backend/src/models/content-type.ts
+++ b/backend/src/models/content-type.ts
@@ -37,6 +37,8 @@ export interface CustomFieldDefinition {
     imageAspectRatio?: string;
     options?: string[];
   };
+  /** Example content from an existing page (for AI context during generation) */
+  exampleContent?: string;
 }
 
 export interface ContentTypeAgent {
@@ -185,8 +187,11 @@ export class ContentTypeStore {
   importFromConnector(
     projectId: string,
     connectorType: string,
-    schemas: Array<{ id: string; label: string; description?: string; category: string; slots: Array<{ id: string; label: string; type: string; required: boolean; constraints?: Record<string, unknown> }> }>,
+    schemas: Array<{ id: string; label: string; description?: string; category: string; slots: Array<{ id: string; label: string; type: string; required: boolean; constraints?: Record<string, unknown>; exampleContent?: string }> }>,
   ): CustomContentType[] {
+    // Load default agent/pipeline from builtin template (if available)
+    const defaultCt = connectorType === "shopware" ? this.get("shopware-landing-page") : null;
+
     const imported: CustomContentType[] = [];
     for (const schema of schemas) {
       const fields: CustomFieldDefinition[] = schema.slots.map((slot, i) => ({
@@ -196,18 +201,35 @@ export class ContentTypeStore {
         required: slot.required,
         sortOrder: i,
         constraints: slot.constraints as CustomFieldDefinition["constraints"],
+        exampleContent: slot.exampleContent,
       }));
 
-      const ct = this.create({
-        projectId,
-        label: schema.label,
-        description: schema.description,
-        category: schema.category as CustomContentType["category"],
-        source: "connector",
-        connectorType,
-        connectorRef: schema.id,
-        fields,
-      });
+      // Check if a content type with this connectorRef already exists → update instead of create
+      const existing = this.list().find((ct) => ct.connectorRef === schema.id && ct.connectorType === connectorType);
+      let ct: CustomContentType;
+      if (existing) {
+        ct = this.update(existing.id, {
+          label: schema.label,
+          description: schema.description,
+          fields,
+          agent: existing.agent ?? defaultCt?.agent,
+          pipeline: existing.pipeline ?? defaultCt?.pipeline,
+        })!;
+        log.info({ id: existing.id, label: schema.label }, "connector content type updated");
+      } else {
+        ct = this.create({
+          projectId,
+          label: schema.label,
+          description: schema.description,
+          category: schema.category as CustomContentType["category"],
+          source: "connector",
+          connectorType,
+          connectorRef: schema.id,
+          fields,
+          agent: defaultCt?.agent,
+          pipeline: defaultCt?.pipeline,
+        });
+      }
       imported.push(ct);
     }
     return imported;

--- a/backend/src/models/content-type.ts
+++ b/backend/src/models/content-type.ts
@@ -96,22 +96,53 @@ export class ContentTypeStore {
 
   list(): CustomContentType[] {
     if (!fs.existsSync(this.basePath)) return [];
-    return fs.readdirSync(this.basePath)
-      .filter((f) => f.endsWith(".json"))
-      .map((f) => {
-        try {
-          return JSON.parse(fs.readFileSync(path.join(this.basePath, f), "utf-8")) as CustomContentType;
-        } catch {
-          return null;
+    const files = fs.readdirSync(this.basePath).filter((f) => f.endsWith(".json"));
+    const byId = new Map<string, { ct: CustomContentType; fileName: string; mtime: number }>();
+
+    for (const f of files) {
+      const filePath = path.join(this.basePath, f);
+      try {
+        const ct = JSON.parse(fs.readFileSync(filePath, "utf-8")) as CustomContentType;
+        const mtime = fs.statSync(filePath).mtimeMs;
+        const existing = byId.get(ct.id);
+
+        if (!existing || mtime > existing.mtime) {
+          if (existing) {
+            // Remove older duplicate
+            const oldPath = path.join(this.basePath, existing.fileName);
+            if (fs.existsSync(oldPath)) {
+              fs.unlinkSync(oldPath);
+              log.info({ id: ct.id, removed: existing.fileName }, "removed duplicate content type file");
+            }
+          }
+          byId.set(ct.id, { ct, fileName: f, mtime });
+        } else {
+          // This file is older — remove it
+          fs.unlinkSync(filePath);
+          log.info({ id: ct.id, removed: f }, "removed duplicate content type file");
         }
-      })
-      .filter((ct): ct is CustomContentType => ct !== null);
+      } catch { /* skip corrupt files */ }
+    }
+
+    // Self-heal: rename files whose name doesn't match their ID
+    for (const [id, entry] of byId) {
+      const expected = `${id}.json`;
+      if (entry.fileName !== expected) {
+        const correctPath = path.join(this.basePath, expected);
+        try {
+          fs.renameSync(path.join(this.basePath, entry.fileName), correctPath);
+          log.info({ id, from: entry.fileName, to: expected }, "self-healed mismatched filename");
+        } catch (err) {
+          log.warn({ id, err }, "failed to self-heal filename");
+        }
+      }
+    }
+
+    return Array.from(byId.values()).map((e) => e.ct);
   }
 
   get(id: string): CustomContentType | null {
-    const filePath = path.join(this.basePath, `${id}.json`);
-    if (!fs.existsSync(filePath)) return null;
-    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as CustomContentType;
+    return this.findById(id)?.ct ?? null;
   }
 
   create(data: Omit<CustomContentType, "id" | "createdAt" | "updatedAt">): CustomContentType {
@@ -137,12 +168,13 @@ export class ContentTypeStore {
   }
 
   delete(id: string): boolean {
-    const filePath = path.join(this.basePath, `${id}.json`);
-    if (!fs.existsSync(filePath)) return false;
-    const ct = this.get(id);
-    if (ct?.source === "builtin") return false; // Protect built-in types
-    fs.unlinkSync(filePath);
+    const found = this.findById(id);
+    if (!found) return false;
+    if (found.ct.source === "builtin") return false;
+    fs.unlinkSync(found.filePath);
     log.info({ id }, "content type deleted");
+    // Clean up any remaining duplicate files with the same ID
+    this.removeDuplicateFiles(id);
     return true;
   }
 
@@ -152,6 +184,52 @@ export class ContentTypeStore {
       JSON.stringify(ct, null, 2),
       "utf-8",
     );
+  }
+
+  /** Find content type file by ID — fast path first, then directory scan with self-healing */
+  private findById(id: string): { ct: CustomContentType; filePath: string } | null {
+    // Fast path: filename matches ID
+    const expectedPath = path.join(this.basePath, `${id}.json`);
+    if (fs.existsSync(expectedPath)) {
+      try {
+        const ct = JSON.parse(fs.readFileSync(expectedPath, "utf-8")) as CustomContentType;
+        if (ct.id === id) return { ct, filePath: expectedPath };
+      } catch { /* fall through to scan */ }
+    }
+
+    // Slow path: scan directory for mismatched filename
+    if (!fs.existsSync(this.basePath)) return null;
+    for (const f of fs.readdirSync(this.basePath).filter((f) => f.endsWith(".json"))) {
+      const filePath = path.join(this.basePath, f);
+      try {
+        const ct = JSON.parse(fs.readFileSync(filePath, "utf-8")) as CustomContentType;
+        if (ct.id === id) {
+          // Self-heal: rename to match ID
+          if (f !== `${id}.json` && !fs.existsSync(expectedPath)) {
+            fs.renameSync(filePath, expectedPath);
+            log.info({ id, from: f, to: `${id}.json` }, "self-healed mismatched filename");
+            return { ct, filePath: expectedPath };
+          }
+          return { ct, filePath };
+        }
+      } catch { /* skip corrupt files */ }
+    }
+    return null;
+  }
+
+  /** Remove all files containing a given ID (used after primary delete to clean up duplicates) */
+  private removeDuplicateFiles(id: string): void {
+    if (!fs.existsSync(this.basePath)) return;
+    for (const f of fs.readdirSync(this.basePath).filter((f) => f.endsWith(".json"))) {
+      const filePath = path.join(this.basePath, f);
+      try {
+        const ct = JSON.parse(fs.readFileSync(filePath, "utf-8")) as CustomContentType;
+        if (ct.id === id) {
+          fs.unlinkSync(filePath);
+          log.info({ id, file: f }, "removed duplicate file during delete");
+        }
+      } catch { /* skip */ }
+    }
   }
 
   /** Sync builtin content types from seed directory.

--- a/frontend/src/app/connectors/page.tsx
+++ b/frontend/src/app/connectors/page.tsx
@@ -115,7 +115,7 @@ function ConnectorsPageContent() {
   const loadGhBranches = useCallback(async (owner: string, repo: string) => {
     if (!ghInstallationId) return;
     setGhLoadingBranches(true);
-    try { setGhBranches(await getGitHubBranches(ghInstallationId, owner, repo)); } catch { /* ignore */ }
+    try { setGhBranches(await getGitHubBranches(ghInstallationId, owner, repo)); } catch (err) { console.error("connector action failed:", err); }
     setGhLoadingBranches(false);
   }, [ghInstallationId]);
 
@@ -156,26 +156,28 @@ function ConnectorsPageContent() {
     setTestStatus((prev) => { const next = { ...prev }; delete next[type]; return next; });
   }, [customerId, projectId, refreshProjects]);
 
-  // Populate state from project data — generic for all connectors + GitHub special case
+  // Sync config values from project data whenever project or connectorDefs change
   useEffect(() => {
-    if (!project || initialized) return;
+    if (!project || connectorDefs.length === 0) return;
 
     // Load GitHub connector (special — has its own state)
-    const ghConn = findConn("github");
-    if (ghConn?.github) {
-      setConnectorType("github");
-      setGhInstallationId(ghConn.github.installationId);
-      setGhOwner(ghConn.github.owner);
-      setGhRepo(ghConn.github.repo);
-      setGhBranch(ghConn.github.branch);
-      setFramework((ghConn.github as { framework?: Framework }).framework ?? "astro");
-      setGhContentPath(ghConn.github.contentPath);
-      setGhAssetsPath(ghConn.github.assetsPath);
-      setGhCategoriesPath(ghConn.github.categoriesPath ?? "src/data/categories.json");
-      setGhAuthorsPath(ghConn.github.authorsPath ?? "src/data/authors.json");
+    if (!initialized) {
+      const ghConn = findConn("github");
+      if (ghConn?.github) {
+        setConnectorType("github");
+        setGhInstallationId(ghConn.github.installationId);
+        setGhOwner(ghConn.github.owner);
+        setGhRepo(ghConn.github.repo);
+        setGhBranch(ghConn.github.branch);
+        setFramework((ghConn.github as { framework?: Framework }).framework ?? "astro");
+        setGhContentPath(ghConn.github.contentPath);
+        setGhAssetsPath(ghConn.github.assetsPath);
+        setGhCategoriesPath(ghConn.github.categoriesPath ?? "src/data/categories.json");
+        setGhAuthorsPath(ghConn.github.authorsPath ?? "src/data/authors.json");
+      }
     }
 
-    // Load all standard connectors generically
+    // Always reload standard connector configs from project data
     const loadedConfigs: Record<string, Record<string, string>> = {};
     for (const def of connectorDefs) {
       if (!def.configKey || !def.fields) continue;
@@ -192,7 +194,7 @@ function ConnectorsPageContent() {
     setConfigValues(loadedConfigs);
     setInitialized(true);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [project, initialized]);
+  }, [project?.connectors, connectorDefs]);
 
   // Handle GitHub OAuth callback
   useEffect(() => {
@@ -607,14 +609,12 @@ function ConnectorsPageContent() {
                                       if (!typeId) return;
                                       try {
                                         const { deleteContentType } = await import("@/lib/api");
+                                        console.log("[REMOVE] clicking remove for", schema.id, "typeId:", typeId);
                                         await deleteContentType(customerId, projectId, typeId);
-                                        const next = new Set(selectedSchemas);
-                                        next.delete(schema.id);
-                                        setSelectedSchemas(next);
-                                        const nextMap = { ...schemaToTypeId };
-                                        delete nextMap[schema.id];
-                                        setSchemaToTypeId(nextMap);
-                                      } catch { /* ignore */ }
+                                        console.log("[REMOVE] deleted successfully");
+                                        setSelectedSchemas((prev) => { const next = new Set(prev); next.delete(schema.id); return next; });
+                                        setSchemaToTypeId((prev) => { const next = { ...prev }; delete next[schema.id]; return next; });
+                                      } catch (err) { console.error("remove failed:", err); }
                                     }}
                                   >
                                     Remove
@@ -624,24 +624,22 @@ function ConnectorsPageContent() {
                                     variant="outline"
                                     size="sm"
                                     className="h-7 text-xs shrink-0"
+                                    disabled={importing}
                                     onClick={async () => {
                                       if (!customerId || !projectId) return;
+                                      setImporting(true);
                                       try {
                                         const result = await importConnectorSchemas(customerId, projectId, [schema.id], activeSchemaConnector);
-                                        const next = new Set(selectedSchemas);
-                                        next.add(schema.id);
-                                        setSelectedSchemas(next);
-                                        // Track the created type ID for later removal
                                         if (result.types?.[0]) {
-                                          setSchemaToTypeId((prev) => ({
-                                            ...prev,
-                                            [schema.id]: (result.types[0] as { id: string }).id,
-                                          }));
+                                          const newId = (result.types[0] as { id: string }).id;
+                                          setSelectedSchemas((prev) => new Set([...prev, schema.id]));
+                                          setSchemaToTypeId((prev) => ({ ...prev, [schema.id]: newId }));
                                         }
-                                      } catch { /* ignore */ }
+                                      } catch (err) { console.error("import failed:", err); }
+                                      finally { setImporting(false); }
                                     }}
                                   >
-                                    Import
+                                    {importing ? <><Loader2 className="mr-1 h-3 w-3 animate-spin" />Importing...</> : "Import"}
                                   </Button>
                                 )}
                               </div>

--- a/frontend/src/app/connectors/page.tsx
+++ b/frontend/src/app/connectors/page.tsx
@@ -614,7 +614,7 @@ function ConnectorsPageContent() {
                                         console.log("[REMOVE] deleted successfully");
                                         setSelectedSchemas((prev) => { const next = new Set(prev); next.delete(schema.id); return next; });
                                         setSchemaToTypeId((prev) => { const next = { ...prev }; delete next[schema.id]; return next; });
-                                      } catch (err) { console.error("remove failed:", err); }
+                                      } catch (err) { console.error("remove failed:", err); alert("Failed to remove content type"); }
                                     }}
                                   >
                                     Remove

--- a/frontend/src/app/content/[id]/page.tsx
+++ b/frontend/src/app/content/[id]/page.tsx
@@ -962,7 +962,7 @@ export default function ContentEditorPage({
           </Link>
           <div className="flex-1 flex items-center gap-2">
             <ContentStatusBadge status={item.status} />
-            <ContentTypeBadge type={item.type} label={contentTypeDef?.label} />
+            <ContentTypeBadge type={item.type} label={contentTypeDef?.label} connectorType={contentTypeDef?.connectorType} />
             {activeVersion && (
               <span className={`text-xs ${isViewingOldVersion ? "text-violet-600 font-medium" : "text-muted-foreground"}`}>
                 v{activeVersion.versionNumber}{isViewingOldVersion ? ` (latest: v${latestVersion!.versionNumber})` : ""}
@@ -1869,10 +1869,6 @@ function JsonEditorSwitch({
     case "newsletter":
       return <NewsletterEditor {...commonProps} />;
     default:
-      // Connector-imported content types with slot structure
-      if (contentType?.connectorType === "shopware" || contentType?.connectorType === "wordpress") {
-        return <ShopwareEditor values={values} onChange={onChange} contentType={contentType} readOnly={readOnly} />;
-      }
       return <GenericEditor values={values} onChange={onChange} contentType={contentType} readOnly={readOnly} />;
   }
 }

--- a/frontend/src/app/content/[id]/page.tsx
+++ b/frontend/src/app/content/[id]/page.tsx
@@ -1882,6 +1882,8 @@ function JsonEditorSwitch({
             onChange={onChange}
             contentType={contentType}
             readOnly={readOnly}
+            customerId={customerId}
+            projectId={projectId}
             onImageUpload={async (file) => {
               const { uploadMedia } = await import("@/lib/api");
               const result = await uploadMedia(customerId ?? "", projectId ?? "", file);

--- a/frontend/src/app/content/[id]/page.tsx
+++ b/frontend/src/app/content/[id]/page.tsx
@@ -1679,6 +1679,8 @@ export default function ContentEditorPage({
             authorRole={typeof authors[0]?.role === "string" ? authors[0].role : authors[0]?.role?.en ?? authors[0]?.role?.de}
             authorImage={authors[0]?.image}
             readOnly={false}
+            customerId={customerId}
+            projectId={projectId}
           />
         )}
       </div>
@@ -1845,6 +1847,8 @@ function JsonEditorSwitch({
   authorRole,
   authorImage,
   readOnly,
+  customerId,
+  projectId,
 }: {
   contentTypeId: string | null;
   contentType: ContentTypeDefinition | null;
@@ -1855,6 +1859,8 @@ function JsonEditorSwitch({
   authorRole?: string;
   authorImage?: string;
   readOnly?: boolean;
+  customerId?: string;
+  projectId?: string;
 }) {
   const commonProps = { values, onChange, projectName, authorName, authorRole, authorImage, readOnly };
   switch (contentTypeId) {
@@ -1869,6 +1875,22 @@ function JsonEditorSwitch({
     case "newsletter":
       return <NewsletterEditor {...commonProps} />;
     default:
+      if (contentType?.connectorType === "shopware" || contentType?.connectorType === "wordpress") {
+        return (
+          <ShopwareEditor
+            values={values}
+            onChange={onChange}
+            contentType={contentType}
+            readOnly={readOnly}
+            onImageUpload={async (file) => {
+              const { uploadMedia } = await import("@/lib/api");
+              const result = await uploadMedia(customerId ?? "", projectId ?? "", file);
+              const { getMediaFileUrl } = await import("@/lib/api");
+              return getMediaFileUrl(customerId ?? "", projectId ?? "", result.asset.id);
+            }}
+          />
+        );
+      }
       return <GenericEditor values={values} onChange={onChange} contentType={contentType} readOnly={readOnly} />;
   }
 }

--- a/frontend/src/app/flows/[id]/page.tsx
+++ b/frontend/src/app/flows/[id]/page.tsx
@@ -351,15 +351,28 @@ export default function FlowDetailPage({ params }: { params: Promise<{ id: strin
   const handleAddContent = async (contentTypeId: string) => {
     if (!customerId || !projectId || !topic) return;
     try {
-      const categoryMap: Record<string, string> = {
+      // Derive type from content type definition
+      const ct = contentTypes.find((t) => t.id === contentTypeId);
+      const typeMap: Record<string, string> = {
         "blog-post": "article", "linkedin-post": "social_post", "instagram-post": "social_post",
         "x-post": "social_post", "tiktok-post": "social_post", "newsletter": "newsletter",
       };
       const platformMap: Record<string, string> = {
         "linkedin-post": "linkedin", "instagram-post": "instagram", "x-post": "x", "tiktok-post": "tiktok",
       };
+      let itemType: string;
+      if (ct?.source === "connector") {
+        itemType = "landing_page";
+      } else if (ct?.category === "social") {
+        itemType = "social_post";
+      } else if (ct?.category === "email") {
+        itemType = "newsletter";
+      } else {
+        itemType = typeMap[contentTypeId] ?? "article";
+      }
       await createContent(customerId, projectId, {
-        type: (categoryMap[contentTypeId] ?? "article") as import("@/lib/types").ContentType,
+        type: itemType as import("@/lib/types").ContentType,
+        contentTypeId,
         title: topic.title,
         category: platformMap[contentTypeId],
         flowId: id,
@@ -666,7 +679,7 @@ export default function FlowDetailPage({ params }: { params: Promise<{ id: strin
                   <DropdownMenuContent>
                     {contentTypes.length > 0 ? contentTypes.map((ct) => (
                       <DropdownMenuItem key={ct.id} className="gap-2" onClick={() => handleAddContent(ct.id)}>
-                        {CT_ICONS[ct.id] ?? CATEGORY_ICONS[ct.category] ?? <FileText className="h-3.5 w-3.5" />}
+                        {getContentTypeIcon(ct)}
                         {ct.label}
                       </DropdownMenuItem>
                     )) : FALLBACK_OUTPUT_OPTIONS.map((opt) => (
@@ -691,7 +704,7 @@ export default function FlowDetailPage({ params }: { params: Promise<{ id: strin
                   <DropdownMenuContent align="start">
                     {contentTypes.length > 0 ? contentTypes.map((ct) => (
                       <DropdownMenuItem key={ct.id} className="gap-2" onClick={() => handleAddContent(ct.id)}>
-                        {CT_ICONS[ct.id] ?? CATEGORY_ICONS[ct.category] ?? <FileText className="h-3.5 w-3.5" />}
+                        {getContentTypeIcon(ct)}
                         {ct.label}
                       </DropdownMenuItem>
                     )) : FALLBACK_OUTPUT_OPTIONS.map((opt) => (
@@ -797,151 +810,7 @@ export default function FlowDetailPage({ params }: { params: Promise<{ id: strin
                   </div>
                 )}
               </div>
-<<<<<<< HEAD
-
-              {/* Onboarding Checklist */}
-              {(outputs.length === 0 || inputs.length === 0) && (
-                <div className="rounded-xl bg-muted/30 p-4 mb-4">
-                  <p className="text-sm font-medium mb-3">Get started</p>
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2.5 text-sm">
-                      <div className={`h-5 w-5 rounded-full border-2 flex items-center justify-center shrink-0 ${inputs.length > 0 ? "border-emerald-500 bg-emerald-500 text-white" : "border-muted-foreground/30"}`}>
-                        {inputs.length > 0 && <Check className="h-3 w-3" />}
-                      </div>
-                      <button type="button" onClick={() => setBottomTab("sources")} className={`hover:underline ${inputs.length > 0 ? "text-muted-foreground line-through" : ""}`}>
-                        Add sources (URLs, documents, images)
-                      </button>
-                    </div>
-                    <div className="flex items-center gap-2.5 text-sm">
-                      <div className={`h-5 w-5 rounded-full border-2 flex items-center justify-center shrink-0 ${outputs.length > 0 ? "border-emerald-500 bg-emerald-500 text-white" : "border-muted-foreground/30"}`}>
-                        {outputs.length > 0 && <Check className="h-3 w-3" />}
-                      </div>
-                      <span className={outputs.length > 0 ? "text-muted-foreground line-through" : ""}>
-                        Create your first content piece
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {outputs.length === 0 ? (
-                <div className="rounded-xl border-2 border-dashed p-10 text-center">
-                  <Package className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
-                  <p className="text-sm font-medium mb-1">No content yet</p>
-                  <p className="text-xs text-muted-foreground mb-4">Create content pieces and generate them with AI or write manually.</p>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="sm" className="rounded-full">
-                        <Plus className="mr-1.5 h-3.5 w-3.5" />Create Content
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      {contentTypes.length > 0 ? contentTypes.map((ct) => (
-                        <DropdownMenuItem key={ct.id} className="gap-2" onClick={() => handleProduce(ct.id)}>
-                          {getContentTypeIcon(ct)}
-                          {ct.label}
-                        </DropdownMenuItem>
-                      )) : FALLBACK_OUTPUT_OPTIONS.map((opt) => (
-                        <DropdownMenuItem key={opt.contentTypeId} className="gap-2" onClick={() => handleProduce(opt.contentTypeId)}>
-                          {opt.icon}{opt.label}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              ) : (
-                <div>
-                  {/* + Create Content row */}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button className="flex items-center gap-3 text-sm text-muted-foreground hover:text-foreground transition-colors py-3 w-full border-b">
-                        <div className="shrink-0 h-9 w-9 rounded-full bg-muted flex items-center justify-center">
-                          <Plus className="h-4 w-4" />
-                        </div>
-                        Create Content
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start">
-                      {contentTypes.length > 0 ? contentTypes.map((ct) => (
-                        <DropdownMenuItem key={ct.id} className="gap-2" onClick={() => handleProduce(ct.id)}>
-                          {getContentTypeIcon(ct)}
-                          {ct.label}
-                        </DropdownMenuItem>
-                      )) : FALLBACK_OUTPUT_OPTIONS.map((opt) => (
-                        <DropdownMenuItem key={opt.contentTypeId} className="gap-2" onClick={() => handleProduce(opt.contentTypeId)}>
-                          {opt.icon}{opt.label}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-
-                  <div className="divide-y mt-1">
-                  {outputs.map((item) => {
-                    const status = STATUS_BADGE[item.status] ?? { label: item.status, variant: "secondary" as const };
-                    const isProducing = item.status === "producing";
-                    const isPlanned = item.status === "planned";
-                    return (
-                      <Link key={item.id} href={`/content/${item.id}`} className="block py-3 hover:bg-muted/30 -mx-2 px-2 rounded-lg transition-colors">
-                        {/* Header row */}
-                        <div className="flex items-center gap-3">
-                          <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-muted-foreground shrink-0">
-                            {(() => {
-                              const ct = item.contentTypeId ? contentTypes.find((t) => t.id === item.contentTypeId) : null;
-                              if (ct) return getContentTypeIcon(ct);
-                              return OUTPUT_ICONS[item.category ?? ""] ?? OUTPUT_ICONS[item.type] ?? <FileText className="h-4 w-4" />;
-                            })()}
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium truncate">{item.title}</p>
-                            <p className="text-xs text-muted-foreground">
-                              {(() => {
-                                const ct = item.contentTypeId ? contentTypes.find((t) => t.id === item.contentTypeId) : null;
-                                if (ct) return ct.label;
-                                return ({ linkedin: "LinkedIn Post", instagram: "Instagram Post", x: "X Post", tiktok: "TikTok Post" } as Record<string, string>)[item.category ?? ""]
-                                  ?? ({ article: "Article", guide: "Guide", newsletter: "Newsletter", social_post: "Social Post" } as Record<string, string>)[item.type]
-                                  ?? item.type.replace("_", " ");
-                              })()}
-                            </p>
-                          </div>
-                          {isProducing && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />}
-                          <Badge variant={status.variant} className="text-xs shrink-0">{status.label}</Badge>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild onClick={(e) => e.preventDefault()}>
-                              <button type="button" className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground shrink-0">
-                                <MoreHorizontal className="h-4 w-4" />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem asChild>
-                                <Link href={`/content/${item.id}`}>
-                                  <Pencil className="mr-2 h-3.5 w-3.5" />Edit
-                                </Link>
-                              </DropdownMenuItem>
-                              {!isProducing && (
-                                <DropdownMenuItem onClick={(e) => { e.preventDefault();
-                                  // Derive contentTypeId from content item type + category
-                                  const ctId = item.type === "social_post" ? `${item.category ?? "linkedin"}-post`
-                                    : item.type === "newsletter" ? "newsletter"
-                                    : "blog-post";
-                                  handleProduce(ctId);
-                                }}>
-                                  <Sparkles className="mr-2 h-3.5 w-3.5" />Generate with AI
-                                </DropdownMenuItem>
-                              )}
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem className="text-destructive" onClick={(e) => { e.preventDefault(); handleDeleteContent(item.id); }}>
-                                <Trash2 className="mr-2 h-3.5 w-3.5" />Delete
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      </Link>
-                    );
-                  })}
-                  </div>
-                </div>
-              )}
-            )
+            )}
             </div>
           </div>
         </div>

--- a/frontend/src/app/settings/content-types/page.tsx
+++ b/frontend/src/app/settings/content-types/page.tsx
@@ -293,8 +293,13 @@ export default function ContentTypesPage() {
                 <Button variant="ghost" size="icon" className="opacity-0 group-hover:opacity-100 text-destructive hover:text-destructive"
                   onClick={async () => {
                     if (!confirm(`Delete "${ct.label}"? This cannot be undone.`)) return;
-                    await deleteContentType(customerId, projectId, ct.id);
-                    setTypes((prev) => prev.filter((t) => t.id !== ct.id));
+                    try {
+                      await deleteContentType(customerId, projectId, ct.id);
+                      setTypes((prev) => prev.filter((t) => t.id !== ct.id));
+                    } catch (err) {
+                      console.error("Delete failed:", err);
+                      alert(`Failed to delete "${ct.label}"`);
+                    }
                   }}>
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>

--- a/frontend/src/components/editors/shopware-editor.tsx
+++ b/frontend/src/components/editors/shopware-editor.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Label } from "@/components/ui/label";
-import { ImageIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ImageIcon, Upload } from "lucide-react";
+import { TiptapEditor } from "@/components/tiptap-editor";
+import { MediaPicker } from "@/components/media-picker";
 
 // ── Slot Layout Parser ──────────────────────────────────────────
 
@@ -11,12 +14,12 @@ interface SlotField {
   label: string;
   type: string;
   slotName: string;
+  exampleContent?: string;
 }
 
 interface Block {
   blockType: string;
   slots: SlotField[];
-  columns: number;
 }
 
 interface Section {
@@ -24,11 +27,10 @@ interface Section {
   blocks: Block[];
 }
 
-function parseSlotLayout(fields: Array<{ id: string; label: string; type: string }>): Section[] {
+function parseSlotLayout(fields: Array<{ id: string; label: string; type: string; exampleContent?: string }>): Section[] {
   const sectionMap = new Map<number, Map<string, SlotField[]>>();
 
   for (const field of fields) {
-    // Parse: s{N}-{blockType}-{slotName}
     const match = field.id.match(/^s(\d+)-(.+)-([^-]+)$/);
     if (!match) continue;
 
@@ -46,19 +48,12 @@ function parseSlotLayout(fields: Array<{ id: string; label: string; type: string
   for (const [index, blockMap] of [...sectionMap.entries()].sort((a, b) => a[0] - b[0])) {
     const blocks: Block[] = [];
     for (const [blockType, slots] of blockMap) {
-      const columns = getBlockColumns(blockType);
-      blocks.push({ blockType, slots, columns });
+      blocks.push({ blockType, slots });
     }
     sections.push({ index, blocks });
   }
 
   return sections;
-}
-
-function getBlockColumns(blockType: string): number {
-  if (blockType.includes("three-column")) return 3;
-  if (blockType.includes("two-column") || blockType.includes("image-text")) return 2;
-  return 1;
 }
 
 function getBlockLabel(blockType: string): string {
@@ -75,11 +70,14 @@ function getBlockLabel(blockType: string): string {
 interface ShopwareEditorProps {
   values: Record<string, unknown>;
   onChange: (values: Record<string, unknown>) => void;
-  contentType: { fields: Array<{ id: string; label: string; type: string }> } | null;
+  contentType: { fields: Array<{ id: string; label: string; type: string; exampleContent?: string }> } | null;
   readOnly?: boolean;
+  onImageUpload?: (file: File) => Promise<string>;
 }
 
-export function ShopwareEditor({ values, onChange, contentType, readOnly }: ShopwareEditorProps) {
+export function ShopwareEditor({ values, onChange, contentType, readOnly, onImageUpload }: ShopwareEditorProps) {
+  const [browseFieldId, setBrowseFieldId] = useState<string | null>(null);
+
   const sections = useMemo(
     () => parseSlotLayout(contentType?.fields ?? []),
     [contentType?.fields],
@@ -90,73 +88,83 @@ export function ShopwareEditor({ values, onChange, contentType, readOnly }: Shop
   }
 
   return (
-    <div className="grid grid-cols-2 gap-6 h-full">
-      {/* Left: Editor */}
-      <div className="overflow-y-auto space-y-6 pr-2">
-        {sections.map((section) => (
-          <div key={section.index} className="space-y-3">
-            {section.blocks.map((block) => (
-              <div key={`${section.index}-${block.blockType}`}>
-                <p className="text-xs font-medium text-muted-foreground mb-2">
-                  Section {section.index} — {getBlockLabel(block.blockType)}
-                </p>
-                <div className={`grid gap-3 ${block.columns === 3 ? "grid-cols-3" : block.columns === 2 ? "grid-cols-2" : "grid-cols-1"}`}>
-                  {block.slots.map((slot) => (
-                    <div key={slot.id} className="space-y-1">
-                      <Label className="text-xs">{slot.slotName}</Label>
-                      {slot.type === "image" ? (
-                        <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/50 aspect-video">
+    <div className="space-y-8">
+      {sections.map((section) => (
+        <div key={section.index} className="space-y-4">
+          {section.blocks.map((block) => (
+            <div key={`${section.index}-${block.blockType}`} className="space-y-3">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Section {section.index} — {getBlockLabel(block.blockType)}
+              </p>
+
+              {block.slots.map((slot) => (
+                <div key={slot.id} className="space-y-1.5">
+                  <Label className="text-xs text-muted-foreground">{slot.slotName}</Label>
+
+                  {slot.type === "image" ? (
+                    // Image slot: preview + browse
+                    <div className="space-y-2">
+                      {values[slot.id] ? (
+                        <img
+                          src={String(values[slot.id])}
+                          alt=""
+                          className="rounded-md border max-h-40 w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/50 h-24">
                           <ImageIcon className="h-5 w-5 text-muted-foreground" />
                         </div>
-                      ) : (
-                        <textarea
-                          value={String(values[slot.id] ?? "")}
-                          onChange={(e) => onChange({ ...values, [slot.id]: e.target.value })}
-                          readOnly={readOnly}
-                          className="w-full rounded-md border bg-background px-3 py-2 text-sm min-h-[80px] resize-y focus:outline-none focus:ring-2 focus:ring-ring"
-                          placeholder={slot.slotName}
-                        />
+                      )}
+                      {!readOnly && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="text-xs"
+                          onClick={() => setBrowseFieldId(slot.id)}
+                        >
+                          <ImageIcon className="mr-1 h-3 w-3" />
+                          Browse
+                        </Button>
                       )}
                     </div>
-                  ))}
+                  ) : slot.type === "rich-text" || slot.type === "markdown" ? (
+                    // Rich text slot: TipTap WYSIWYG
+                    <TiptapEditor
+                      content={String(values[slot.id] ?? "")}
+                      onChange={(md) => onChange({ ...values, [slot.id]: md })}
+                      editable={!readOnly}
+                      onImageUpload={onImageUpload}
+                    />
+                  ) : (
+                    // Other slots: plain textarea
+                    <textarea
+                      value={String(values[slot.id] ?? "")}
+                      onChange={(e) => onChange({ ...values, [slot.id]: e.target.value })}
+                      readOnly={readOnly}
+                      className="w-full rounded-md border bg-background px-3 py-2 text-sm min-h-[80px] resize-y focus:outline-none focus:ring-2 focus:ring-ring"
+                      placeholder={slot.exampleContent ? `Example: ${slot.exampleContent.slice(0, 100)}...` : slot.slotName}
+                    />
+                  )}
                 </div>
-              </div>
-            ))}
-          </div>
-        ))}
-      </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ))}
 
-      {/* Right: Preview */}
-      <div className="overflow-y-auto border rounded-lg bg-white p-4 space-y-4">
-        <p className="text-xs font-medium text-muted-foreground">Preview</p>
-        {sections.map((section) => (
-          <div key={section.index} className="space-y-2">
-            {section.blocks.map((block) => (
-              <div
-                key={`${section.index}-${block.blockType}`}
-                className={`grid gap-3 ${block.columns === 3 ? "grid-cols-3" : block.columns === 2 ? "grid-cols-2" : "grid-cols-1"}`}
-              >
-                {block.slots.map((slot) => (
-                  <div key={slot.id} className="min-h-[40px]">
-                    {slot.type === "image" ? (
-                      <div className="flex items-center justify-center rounded bg-muted aspect-video">
-                        <ImageIcon className="h-6 w-6 text-muted-foreground/50" />
-                      </div>
-                    ) : values[slot.id] ? (
-                      <div
-                        className="prose prose-sm max-w-none text-sm"
-                        dangerouslySetInnerHTML={{ __html: String(values[slot.id]) }}
-                      />
-                    ) : (
-                      <div className="rounded bg-muted/30 h-full min-h-[40px]" />
-                    )}
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-        ))}
-      </div>
+      {/* MediaPicker for image slots */}
+      <MediaPicker
+        open={!!browseFieldId}
+        onOpenChange={(open) => { if (!open) setBrowseFieldId(null); }}
+        typeFilter="image"
+        onSelect={(asset) => {
+          if (browseFieldId) {
+            // Use the thumbnail URL from the asset
+            onChange({ ...values, [browseFieldId]: asset.id });
+            setBrowseFieldId(null);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/editors/shopware-editor.tsx
+++ b/frontend/src/components/editors/shopware-editor.tsx
@@ -3,9 +3,10 @@
 import { useMemo, useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import { ImageIcon, Upload } from "lucide-react";
+import { ImageIcon, Upload, Package } from "lucide-react";
 import { TiptapEditor } from "@/components/tiptap-editor";
 import { MediaPicker } from "@/components/media-picker";
+import { getMediaFileUrl } from "@/lib/api";
 
 // ── Slot Layout Parser ──────────────────────────────────────────
 
@@ -65,6 +66,18 @@ function getBlockLabel(blockType: string): string {
   return "Content";
 }
 
+function getBlockGridClass(blockType: string): string {
+  if (blockType.includes("three-column")) return "grid grid-cols-3 gap-4";
+  if (blockType.includes("two-column") || blockType.includes("image-text")) return "grid grid-cols-2 gap-4";
+  return "space-y-3";
+}
+
+const slotOrder: Record<string, number> = { left: 0, "center-left": 1, center: 2, "center-right": 3, right: 4 };
+
+function sortSlots(slots: SlotField[]): SlotField[] {
+  return [...slots].sort((a, b) => (slotOrder[a.slotName] ?? 9) - (slotOrder[b.slotName] ?? 9));
+}
+
 // ── Editor Component ────────────────────────────────────────────
 
 interface ShopwareEditorProps {
@@ -73,9 +86,11 @@ interface ShopwareEditorProps {
   contentType: { fields: Array<{ id: string; label: string; type: string; exampleContent?: string }> } | null;
   readOnly?: boolean;
   onImageUpload?: (file: File) => Promise<string>;
+  customerId?: string;
+  projectId?: string;
 }
 
-export function ShopwareEditor({ values, onChange, contentType, readOnly, onImageUpload }: ShopwareEditorProps) {
+export function ShopwareEditor({ values, onChange, contentType, readOnly, onImageUpload, customerId, projectId }: ShopwareEditorProps) {
   const [browseFieldId, setBrowseFieldId] = useState<string | null>(null);
 
   const sections = useMemo(
@@ -97,36 +112,42 @@ export function ShopwareEditor({ values, onChange, contentType, readOnly, onImag
                 Section {section.index} — {getBlockLabel(block.blockType)}
               </p>
 
-              {block.slots.map((slot) => (
-                <div key={slot.id} className="space-y-1.5">
+              <div className={getBlockGridClass(block.blockType)}>
+              {sortSlots(block.slots).map((slot, idx) => (
+                <div key={`${slot.id}-${idx}`} className="space-y-1.5">
                   <Label className="text-xs text-muted-foreground">{slot.slotName}</Label>
 
                   {slot.type === "image" ? (
-                    // Image slot: preview + browse
-                    <div className="space-y-2">
+                    // Image slot: click to browse, drag to upload
+                    <button
+                      type="button"
+                      disabled={readOnly}
+                      onClick={() => !readOnly && setBrowseFieldId(slot.id)}
+                      onDragOver={(e) => { if (!readOnly) { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; } }}
+                      onDrop={async (e) => {
+                        e.preventDefault();
+                        if (readOnly || !onImageUpload) return;
+                        const file = e.dataTransfer.files[0];
+                        if (file?.type.startsWith("image/")) {
+                          const url = await onImageUpload(file);
+                          onChange({ ...values, [slot.id]: url });
+                        }
+                      }}
+                      className="w-full rounded-md border border-dashed bg-muted/50 overflow-hidden cursor-pointer hover:border-primary/50 transition-colors disabled:cursor-default"
+                    >
                       {values[slot.id] ? (
                         <img
                           src={String(values[slot.id])}
                           alt=""
-                          className="rounded-md border max-h-40 w-full object-cover"
+                          className="w-full aspect-video object-cover"
                         />
                       ) : (
-                        <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/50 h-24">
+                        <div className="flex flex-col items-center justify-center h-24 gap-1">
                           <ImageIcon className="h-5 w-5 text-muted-foreground" />
+                          <span className="text-xs text-muted-foreground">Click or drop image</span>
                         </div>
                       )}
-                      {!readOnly && (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="text-xs"
-                          onClick={() => setBrowseFieldId(slot.id)}
-                        >
-                          <ImageIcon className="mr-1 h-3 w-3" />
-                          Browse
-                        </Button>
-                      )}
-                    </div>
+                    </button>
                   ) : slot.type === "rich-text" || slot.type === "markdown" ? (
                     // Rich text slot: TipTap WYSIWYG
                     <TiptapEditor
@@ -135,6 +156,14 @@ export function ShopwareEditor({ values, onChange, contentType, readOnly, onImag
                       editable={!readOnly}
                       onImageUpload={onImageUpload}
                     />
+                  ) : slot.type === "json" && (slot.id.includes("product") || slot.slotName.includes("product")) ? (
+                    // Product slot: hint to add sources
+                    <div className="rounded-md border border-dashed bg-muted/30 p-4 text-center">
+                      <Package className="h-5 w-5 text-muted-foreground mx-auto mb-1" />
+                      <p className="text-xs text-muted-foreground">
+                        Product selection — add products as sources in your flow, then AI will choose relevant ones for this slot.
+                      </p>
+                    </div>
                   ) : (
                     // Other slots: plain textarea
                     <textarea
@@ -147,6 +176,7 @@ export function ShopwareEditor({ values, onChange, contentType, readOnly, onImag
                   )}
                 </div>
               ))}
+              </div>
             </div>
           ))}
         </div>
@@ -158,9 +188,9 @@ export function ShopwareEditor({ values, onChange, contentType, readOnly, onImag
         onOpenChange={(open) => { if (!open) setBrowseFieldId(null); }}
         typeFilter="image"
         onSelect={(asset) => {
-          if (browseFieldId) {
-            // Use the thumbnail URL from the asset
-            onChange({ ...values, [browseFieldId]: asset.id });
+          if (browseFieldId && customerId && projectId) {
+            const url = getMediaFileUrl(customerId, projectId, asset.id);
+            onChange({ ...values, [browseFieldId]: url });
             setBrowseFieldId(null);
           }
         }}

--- a/frontend/src/components/status-badge.tsx
+++ b/frontend/src/components/status-badge.tsx
@@ -1,4 +1,5 @@
 import type { TopicStatus, PhaseStatus, ContentItemStatus, ContentType, ContentStatus } from "@/lib/types";
+import { ShoppingBag, Globe } from "lucide-react";
 
 // ── Topic Status Badge ───────────────────────────────────────────
 
@@ -127,10 +128,16 @@ const contentTypeConfig: Record<ContentType, { label: string; className: string 
   newsletter: { label: "Newsletter", className: "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300" },
 };
 
-export function ContentTypeBadge({ type, label }: { type: ContentType; label?: string }) {
+const CONNECTOR_BADGE_ICONS: Record<string, React.ReactNode> = {
+  shopware: <ShoppingBag className="h-3 w-3 mr-0.5" />,
+  wordpress: <Globe className="h-3 w-3 mr-0.5" />,
+};
+
+export function ContentTypeBadge({ type, label, connectorType }: { type: ContentType; label?: string; connectorType?: string }) {
   const config = contentTypeConfig[type];
   return (
     <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${config.className}`}>
+      {connectorType && CONNECTOR_BADGE_ICONS[connectorType]}
       {label ?? config.label}
     </span>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -434,7 +434,7 @@ export function getContentItem(
 export function createContent(
   customerId: string,
   projectId: string,
-  data: { type: ContentType; title: string; description?: string; category?: string; tags?: string[]; keywords?: string[]; flowId?: string },
+  data: { type: ContentType; contentTypeId?: string; title: string; description?: string; category?: string; tags?: string[]; keywords?: string[]; flowId?: string },
 ): Promise<ContentItem> {
   return fetchJson(`/customers/${customerId}/projects/${projectId}/content`, {
     method: "POST",


### PR DESCRIPTION
## Summary

- ShopwareEditor mit TipTap WYSIWYG für Rich-Text-Slots + MediaPicker für Bild-Slots
- Builtin Content Type mit Agent/Pipeline, exampleContent aus Live-Slots, Connector-Badge-Icons
- ContentTypeStore: Self-Healing bei Dateiname-ID-Mismatch, Deduplizierung, robustes Delete
- Grid-Layout im Editor für Multi-Column-Blöcke (Two/Three Columns, Image+Text)
- Fehler-Feedback bei Delete/Remove statt stillem Scheitern

## Test plan

- [ ] Content Type über Connector importieren und im Editor öffnen - Grid-Layout prüfen
- [ ] Content Type löschen und Seite neu laden - darf nicht wieder auftauchen
- [ ] Im Connector Remove klicken - muss funktionieren, bei Fehler alert zeigen
- [ ] Duplikate auf Platte anlegen (`cp branchen.json "branchen 2.json"`) - list() muss deduplizieren