### PR TITLE
feat: inbox, intelligence improvements, sidebar refinements

### DIFF
--- a/backend/src/agents/workflows/competitor-scan.ts
+++ b/backend/src/agents/workflows/competitor-scan.ts
@@ -4,8 +4,7 @@ import { createLogger } from "../../utils/logger.js";
 import { PipelineContext } from "../../pipeline/context.js";
 import { JobStore } from "../../models/job.js";
 import { MemoryStore } from "../../models/memory.js";
-import { executeJob } from "../executor.js";
-import { extractJson } from "../../pipeline/extract-json.js";
+// executeJob and extractJson no longer needed — no AI classification step
 import {
   discoverSitemapUrl,
   fetchSitemap,
@@ -14,7 +13,7 @@ import {
   type CrawledPage,
 } from "../../services/sitemap-crawler.js";
 import { analyzeCompetitor, type CrawlProfile } from "../../services/crawl-profiler.js";
-import { classifyBatch } from "../../services/topic-classifier.js";
+// topic-classifier.ts no longer used — categories extracted from pages directly
 import { computeTopicCoverage, computeGapMatrix, computeCompetitorIndex } from "../../services/gap-analyzer.js";
 import type {
   Job,
@@ -172,19 +171,16 @@ export async function runCompetitorScan(
       if (page.estimatedWordCount < 200) continue; // Too short
       if (!page.title || page.title.length < 5) continue; // No title at all
 
-      // Use H2s for classification, fall back to H3s if H2s are empty (nav-filtered)
-      const headingsForClassify = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
-      const cluster = classifyBatch([{ url: page.url, title: page.title, h2Headings: headingsForClassify }]);
-      const topicCluster = cluster.classified[0]?.topicCluster ?? null;
+      // Category: only use what the page itself declares. Never invent categories.
+      const topicCluster: string | null = page.category ?? null;
 
-      // Store both H2s and H3s — show whichever is the actual content structure
       const contentHeadings = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
 
       newArticles.push({
         url: page.url,
         title: page.title,
         slug: page.slug,
-        publishedAt: entry.lastmod ?? null,
+        publishedAt: entry.lastmod ?? page.publishedAt ?? null,
         discoveredAt: now(),
         topicCluster,
         h2Headings: contentHeadings,
@@ -238,59 +234,16 @@ export async function runCompetitorScan(
     log.info({ competitor: slug, newArticles: newArticles.length, total: blogIndex.totalArticles }, "blog index updated");
   }
 
-  // ── Step 4: Agent classification for unclassified articles ───
-  const unclassified = allNewArticles
+  // ── Step 4: Report unclassified articles (no AI guessing) ──
+  const unclassifiedCount = allNewArticles
     .flatMap(({ articles }) => articles)
-    .filter((a) => a.topicCluster === null && a.title);
+    .filter((a) => a.topicCluster === null).length;
+  const classifiedCount = allNewArticles
+    .flatMap(({ articles }) => articles)
+    .filter((a) => a.topicCluster !== null).length;
 
   ctx.startPhase("classify");
-  if (unclassified.length > 0) {
-    logEvent("classify", "agent-classify", `${unclassified.length} articles need AI classification`);
-    log.info({ count: unclassified.length }, "classifying unclassified articles via agent");
-
-    const classifyJob = jobs.create({
-      customerId: ctx.customerId,
-      projectId: project.id,
-      type: "custom" as Job["type"],
-      assigneeAgent: "monitor-competitors",
-      status: "queued",
-      title: `Classify ${unclassified.length} competitor articles`,
-      description: "Assign topic clusters to articles that couldn't be classified by keywords",
-      input: {
-        articles: unclassified.map((a) => ({ url: a.url, title: a.title, h2s: a.h2Headings?.slice(0, 5) })),
-      },
-      comments: [],
-      createdAt: now(),
-      runId: ctx.run.id,
-    }) as Job;
-
-    jobs.transition(classifyJob.id, "in_progress");
-    try {
-      const result = await executeJob(ctx, classifyJob);
-      const classifications = extractJson(result.text) as Array<{ url: string; cluster: string }> | null;
-      if (Array.isArray(classifications)) {
-        // Apply classifications back to blog indexes
-        for (const { url, cluster } of classifications) {
-          for (const { competitor } of allNewArticles) {
-            const dir = `areas/competitors/${competitor}`;
-            const idx = memory.load<CompetitorBlogIndex>(`${dir}/blog-index.json`);
-            if (!idx) continue;
-            const article = idx.articles.find((a) => a.url === url);
-            if (article) {
-              article.topicCluster = cluster;
-              memory.save(`${dir}/blog-index.json`, idx, "competitor-scan");
-            }
-          }
-        }
-      }
-      jobs.transition(classifyJob.id, "done");
-    } catch (err) {
-      log.warn({ err }, "agent classification failed, proceeding with keyword-only classifications");
-      jobs.transition(classifyJob.id, "failed");
-    }
-  }
-
-  logEvent("classify", "done", `Classification complete`);
+  logEvent("classify", "done", `${classifiedCount} categorized from page, ${unclassifiedCount} uncategorized`);
   ctx.completePhase("classify");
 
   // ── Step 5: Recompute topic coverage per competitor ──────────
@@ -442,13 +395,12 @@ export async function runSingleCompetitorScan(
   for (const entry of toCrawl) {
     const page = await crawlPage(entry.url);
     if (!page || page.estimatedWordCount < 200 || !page.title || page.title.length < 5) continue;
-    const headingsForClassify = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
-    const cluster = classifyBatch([{ url: page.url, title: page.title, h2Headings: headingsForClassify }]);
+    const topicCluster2: string | null = page.category ?? null;
     const contentHeadings = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
     newArticles.push({
       url: page.url, title: page.title, slug: page.slug,
-      publishedAt: entry.lastmod ?? null, discoveredAt: now(),
-      topicCluster: cluster.classified[0]?.topicCluster ?? null,
+      publishedAt: entry.lastmod ?? page.publishedAt ?? null, discoveredAt: now(),
+      topicCluster: topicCluster2,
       h2Headings: contentHeadings, estimatedWordCount: page.estimatedWordCount, hasBeenAnalyzed: true,
     });
   }

--- a/backend/src/agents/workflows/competitor-scan.ts
+++ b/backend/src/agents/workflows/competitor-scan.ts
@@ -18,6 +18,7 @@ import { classifyBatch } from "../../services/topic-classifier.js";
 import { computeTopicCoverage, computeGapMatrix, computeCompetitorIndex } from "../../services/gap-analyzer.js";
 import type {
   Job,
+  Competitor,
   CompetitorBlogIndex,
   CompetitorArticle,
   CompetitorProfile,
@@ -187,6 +188,7 @@ export async function runCompetitorScan(
         discoveredAt: now(),
         topicCluster,
         h2Headings: contentHeadings,
+        h3Headings: page.h3Headings,
         estimatedWordCount: page.estimatedWordCount,
         hasBeenAnalyzed: true,
       });
@@ -357,4 +359,168 @@ export async function runCompetitorScan(
     },
     "competitor scan completed",
   );
+}
+
+/**
+ * Scan a single competitor (not all). Used by per-competitor "Re-scan" button.
+ * Runs the same crawl + classify + gap-analyze flow but only for one competitor.
+ */
+export async function runSingleCompetitorScan(
+  ctx: PipelineContext,
+  jobs: JobStore,
+  comp: Competitor,
+): Promise<void> {
+  const { project } = ctx;
+  const memory = new MemoryStore(ctx.projectDir);
+  const now = () => new Date().toISOString();
+  const slug = domainSlug(comp.domain);
+  const competitorDir = `areas/competitors/${slug}`;
+  const phaseName = `crawl:${comp.name}`;
+
+  ctx.updateRun({ status: "running", startedAt: now() });
+
+  function logEvent(phase: string, tool: string, input: string) {
+    try {
+      ctx.stores.pipelineRuns.addAgentCall(ctx.run.id, phase, {
+        agent: "competitor-scan",
+        model: "code",
+        status: "completed",
+        costUsd: 0,
+        tokens: { input: 0, output: 0 },
+        durationMs: 0,
+        events: [{ type: "tool_call", timestamp: now(), tool, input }],
+      });
+    } catch { /* ignore */ }
+  }
+
+  ctx.startPhase(phaseName);
+
+  // Load profile or use auto-discovery
+  let profile = memory.load<CrawlProfile>(`${competitorDir}/crawl-profile.json`);
+  if (!profile) {
+    logEvent(phaseName, "analyze-site", `First scan — analyzing ${comp.domain}`);
+    try {
+      profile = await analyzeCompetitor(comp.domain, comp.name, ctx.projectDir);
+      logEvent(phaseName, "profile-created", `Method: ${profile.extraction.method}`);
+    } catch {
+      logEvent(phaseName, "profile-fallback", "Profiler failed, using auto-discovery");
+    }
+  }
+
+  let blogIndex = memory.load<CompetitorBlogIndex>(`${competitorDir}/blog-index.json`) ?? {
+    competitorSlug: slug, sitemapUrl: profile?.blog.sitemapUrl ?? null, lastCrawlAt: "", totalArticles: 0, articles: [],
+  };
+
+  if (!blogIndex.sitemapUrl) {
+    blogIndex.sitemapUrl = profile?.blog.sitemapUrl ?? await discoverSitemapUrl(comp.domain);
+  }
+
+  if (!blogIndex.sitemapUrl) {
+    logEvent(phaseName, "error", "No sitemap found");
+    ctx.completePhase(phaseName);
+    ctx.updateRun({ status: "completed", completedAt: now() });
+    return;
+  }
+
+  logEvent(phaseName, "fetch-sitemap", blogIndex.sitemapUrl);
+  let sitemapEntries = await fetchSitemap(blogIndex.sitemapUrl);
+
+  const pathFilter = profile?.blog.pathFilter;
+  if (pathFilter) {
+    sitemapEntries = sitemapEntries.filter((e) => e.url.includes(pathFilter));
+    logEvent(phaseName, "path-filter", `${pathFilter}: ${sitemapEntries.length} URLs`);
+  }
+
+  const knownUrls = new Set(blogIndex.articles.map((a) => a.url));
+  const { newEntries } = diffArticles(knownUrls, sitemapEntries);
+  logEvent(phaseName, "diff", `${newEntries.length} new URLs (${knownUrls.size} known)`);
+
+  const toCrawl = newEntries.slice(0, MAX_PAGES_TO_CRAWL_PER_SCAN);
+  logEvent(phaseName, "crawl-start", `Crawling ${toCrawl.length} pages`);
+
+  const newArticles: CompetitorArticle[] = [];
+  for (const entry of toCrawl) {
+    const page = await crawlPage(entry.url);
+    if (!page || page.estimatedWordCount < 200 || !page.title || page.title.length < 5) continue;
+    const headingsForClassify = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
+    const cluster = classifyBatch([{ url: page.url, title: page.title, h2Headings: headingsForClassify }]);
+    const contentHeadings = page.h2Headings.length > 0 ? page.h2Headings : page.h3Headings;
+    newArticles.push({
+      url: page.url, title: page.title, slug: page.slug,
+      publishedAt: entry.lastmod ?? null, discoveredAt: now(),
+      topicCluster: cluster.classified[0]?.topicCluster ?? null,
+      h2Headings: contentHeadings, estimatedWordCount: page.estimatedWordCount, hasBeenAnalyzed: true,
+    });
+  }
+
+  blogIndex.articles.push(...newArticles);
+  blogIndex.totalArticles = blogIndex.articles.length;
+  blogIndex.lastCrawlAt = now();
+  memory.save(`${competitorDir}/blog-index.json`, blogIndex, "competitor-scan");
+
+  if (!memory.load(`${competitorDir}/profile.json`)) {
+    memory.save(`${competitorDir}/profile.json`, {
+      slug, name: comp.name, domain: comp.domain, description: "", blogUrl: comp.domain,
+      sitemapUrl: blogIndex.sitemapUrl, channels: ["blog"], knownStrengths: [], knownWeaknesses: [],
+      notes: comp.notes ?? "", createdAt: now(), updatedAt: now(),
+    } satisfies CompetitorProfile, "competitor-scan");
+  }
+
+  memory.save(`${competitorDir}/recent-activity.json`, {
+    competitorSlug: slug, updatedAt: now(),
+    newArticles: newArticles.map((a) => ({ url: a.url, title: a.title, topicCluster: a.topicCluster, publishedAt: a.publishedAt })),
+  } satisfies CompetitorRecentActivity, "competitor-scan");
+
+  logEvent(phaseName, "indexed", `${newArticles.length} articles saved (${blogIndex.totalArticles} total)`);
+  ctx.completePhase(phaseName);
+
+  // Recompute coverage + gap matrix for all competitors
+  ctx.startPhase("classify");
+  logEvent("classify", "done", "Classification complete");
+  ctx.completePhase("classify");
+
+  ctx.startPhase("analyze");
+  logEvent("analyze", "compute-coverage", "Recomputing topic coverage");
+
+  const allCompetitors = project.competitors ?? [];
+  const competitorCoverages: Array<{ slug: string; coverage: ReturnType<typeof computeTopicCoverage> }> = [];
+  for (const c of allCompetitors) {
+    const s = domainSlug(c.domain);
+    const idx = memory.load<CompetitorBlogIndex>(`areas/competitors/${s}/blog-index.json`);
+    if (!idx) continue;
+    const coverage = computeTopicCoverage(s, idx);
+    memory.save(`areas/competitors/${s}/topic-coverage.json`, coverage, "competitor-scan");
+    competitorCoverages.push({ slug: s, coverage });
+  }
+
+  const ourArticlesByCluster: Record<string, number> = {};
+  const contentIndexPath = path.join(ctx.projectDir, "content-index.json");
+  if (fs.existsSync(contentIndexPath)) {
+    try {
+      const contentIndex = JSON.parse(fs.readFileSync(contentIndexPath, "utf-8")) as ContentIndex;
+      for (const entry of contentIndex.entries ?? []) {
+        const category = entry.site?.category ?? "uncategorized";
+        ourArticlesByCluster[category] = (ourArticlesByCluster[category] ?? 0) + 1;
+      }
+    } catch { /* ignore */ }
+  }
+
+  const gapMatrix = computeGapMatrix(project.id, ourArticlesByCluster, competitorCoverages);
+  memory.save("areas/competitors/_gap-matrix.json", gapMatrix, "competitor-scan");
+
+  const blogIndexes = allCompetitors.map((c) => {
+    const s = domainSlug(c.domain);
+    const idx = memory.load<CompetitorBlogIndex>(`areas/competitors/${s}/blog-index.json`);
+    return { slug: s, name: c.name, domain: c.domain, blogUrl: c.domain, sitemapUrl: idx?.sitemapUrl ?? null,
+      index: idx ?? { competitorSlug: s, sitemapUrl: null, lastCrawlAt: "", totalArticles: 0, articles: [] } };
+  });
+  const ourArticleCount = Object.values(ourArticlesByCluster).reduce((a, b) => a + b, 0);
+  const competitorIndex = computeCompetitorIndex(project.id, blogIndexes, gapMatrix, ourArticleCount);
+  memory.save("areas/competitors/_index.json", competitorIndex, "competitor-scan");
+
+  logEvent("analyze", "done", `Scan complete — ${newArticles.length} new articles for ${comp.name}`);
+  ctx.completePhase("analyze");
+  ctx.updateRun({ status: "completed", completedAt: now() });
+
+  log.info({ competitor: slug, newArticles: newArticles.length, total: blogIndex.totalArticles }, "single competitor scan completed");
 }

--- a/backend/src/api/routes/cmo.ts
+++ b/backend/src/api/routes/cmo.ts
@@ -264,6 +264,67 @@ export async function cmoRoutes(app: FastifyInstance) {
     },
   );
 
+  // POST /cmo/competitors/:slug/scan — scan a single competitor
+  app.post<{
+    Params: { customerId: string; projectId: string; slug: string };
+  }>(
+    "/competitors/:slug/scan",
+    async (request, reply) => {
+      const { customerId, projectId, slug } = request.params;
+      const project = app.ctx.projectsFor(customerId).get(projectId);
+      if (!project) return reply.status(404).send({ error: "Project not found" });
+
+      // Find this competitor in settings
+      const comp = (project.competitors ?? []).find((c) => {
+        const s = c.domain.replace(/^https?:\/\//, "").replace(/^www\./, "").replace(/\/$/, "").replace(/\..+$/, "").replace(/[^a-z0-9]/gi, "-").toLowerCase();
+        return s === slug;
+      });
+      if (!comp) return reply.status(404).send({ error: "Competitor not found in settings" });
+
+      // Create a pipeline run with just this competitor
+      const run = app.ctx.pipelineRunsFor(customerId, projectId).create({
+        customerId,
+        projectId,
+        type: "strategy",
+        status: "pending",
+        phases: [
+          { name: `crawl:${comp.name}`, status: "pending" as const, agentCalls: [] },
+          { name: "classify", status: "pending" as const, agentCalls: [] },
+          { name: "analyze", status: "pending" as const, agentCalls: [] },
+        ],
+        totalCostUsd: 0,
+        totalTokens: { input: 0, output: 0 },
+        createdAt: new Date().toISOString(),
+      });
+
+      // Run scan for just this competitor
+      const { PipelineContext } = await import("../../pipeline/context.js");
+      const ctx = new PipelineContext(
+        customerId, project, run,
+        {
+          customers: app.ctx.customers,
+          projects: app.ctx.projectsFor(customerId),
+          content: app.ctx.contentFor(customerId, projectId),
+          pipelineRuns: app.ctx.pipelineRunsFor(customerId, projectId),
+          topics: app.ctx.topicsFor(customerId, projectId),
+        },
+        app.ctx.dataDir,
+      );
+
+      const jobs = app.ctx.jobsFor(customerId, projectId);
+
+      // Import and run single-competitor scan
+      (async () => {
+        const { runSingleCompetitorScan } = await import("../../agents/workflows/competitor-scan.js");
+        await runSingleCompetitorScan(ctx, jobs, comp).catch((err) => {
+          log.error({ err, slug }, "single competitor scan failed");
+        });
+      })();
+
+      return { message: `Scan started for ${comp.name}`, runId: run.id };
+    },
+  );
+
   // POST /cmo/competitors/onboard — analyze a new competitor with live events
   app.post<{
     Params: { customerId: string; projectId: string };

--- a/backend/src/api/routes/cmo.ts
+++ b/backend/src/api/routes/cmo.ts
@@ -238,4 +238,131 @@ export async function cmoRoutes(app: FastifyInstance) {
       };
     },
   );
+
+  // DELETE /cmo/competitors/:slug — remove competitor from memory
+  app.delete<{ Params: { customerId: string; projectId: string; slug: string } }>(
+    "/competitors/:slug",
+    async (request) => {
+      const { customerId, projectId, slug } = request.params;
+      const memory = app.ctx.memoryFor(customerId, projectId);
+
+      // Remove per-competitor memory files
+      const fs = await import("node:fs");
+      const competitorDir = path.join(memory.getDir(), "areas", "competitors", slug);
+      if (fs.existsSync(competitorDir)) {
+        fs.rmSync(competitorDir, { recursive: true });
+      }
+
+      // Update _index.json — remove this competitor
+      const index = memory.load<{ competitors: Array<{ slug: string }> }>("areas/competitors/_index.json");
+      if (index) {
+        index.competitors = index.competitors.filter((c) => c.slug !== slug);
+        memory.save("areas/competitors/_index.json", index, "user");
+      }
+
+      return { message: `Competitor ${slug} removed` };
+    },
+  );
+
+  // POST /cmo/competitors/onboard — analyze a new competitor with live events
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: { domain: string; name: string };
+  }>(
+    "/competitors/onboard",
+    async (request, reply) => {
+      const { customerId, projectId } = request.params;
+      const { domain, name } = (request.body ?? {}) as { domain?: string; name?: string };
+
+      if (!domain || !name) return reply.status(400).send({ error: "domain and name required" });
+
+      const projectDir = path.join(app.ctx.dataDir, "customers", customerId, "projects", projectId);
+
+      // Create a pipeline run to track events
+      const run = app.ctx.pipelineRunsFor(customerId, projectId).create({
+        customerId,
+        projectId,
+        type: "strategy",
+        status: "pending",
+        phases: [
+          { name: "discover-sitemap", status: "pending" as const, agentCalls: [] },
+          { name: "test-extraction", status: "pending" as const, agentCalls: [] },
+          { name: "create-profile", status: "pending" as const, agentCalls: [] },
+        ],
+        totalCostUsd: 0,
+        totalTokens: { input: 0, output: 0 },
+        createdAt: new Date().toISOString(),
+      });
+
+      const runStore = app.ctx.pipelineRunsFor(customerId, projectId);
+
+      // Run profiler async with event tracking
+      (async () => {
+        runStore.update(run.id, { status: "running", startedAt: new Date().toISOString() });
+        try {
+          const { analyzeCompetitor } = await import("../../services/crawl-profiler.js");
+          await analyzeCompetitor(domain, name, projectDir, (event) => {
+            // Map events to pipeline phases + agent calls
+            const phaseMap: Record<string, string> = {
+              "discover-sitemap": "discover-sitemap",
+              "detect-blog-path": "discover-sitemap",
+              "test-extraction": "test-extraction",
+              "analyze-sample": "test-extraction",
+              "profile-created": "create-profile",
+              "complete": "create-profile",
+            };
+            const phaseName = phaseMap[event.step] ?? "test-extraction";
+
+            if (event.status === "running") {
+              runStore.updatePhase(run.id, phaseName, { status: "running", startedAt: new Date().toISOString() });
+            }
+
+            // Add event as agent call
+            runStore.addAgentCall(run.id, phaseName, {
+              agent: "crawl-profiler",
+              model: "code",
+              status: event.status === "error" ? "failed" : "completed",
+              costUsd: 0,
+              tokens: { input: 0, output: 0 },
+              durationMs: 0,
+              events: [{
+                type: "tool_call",
+                timestamp: new Date().toISOString(),
+                tool: event.step,
+                input: event.detail ?? "",
+              }],
+            });
+
+            if (event.status === "done" && (event.step === "profile-created" || event.step === "discover-sitemap")) {
+              runStore.updatePhase(run.id, phaseName, { status: "completed", completedAt: new Date().toISOString() });
+            }
+          });
+
+          // Add to _index.json so it appears in the UI immediately
+          const memory2 = app.ctx.memoryFor(customerId, projectId);
+          const slug2 = domain.replace(/^https?:\/\//, "").replace(/^www\./, "").replace(/\/$/, "").replace(/\..+$/, "").replace(/[^a-z0-9]/gi, "-").toLowerCase();
+          const existingIndex = memory2.load<{ competitors: Array<Record<string, unknown>>; [k: string]: unknown }>("areas/competitors/_index.json") ?? { projectId, updatedAt: new Date().toISOString(), competitors: [], ourTotalArticles: 0, topGaps: [], topOpportunities: [] };
+          if (!existingIndex.competitors.some((c) => c.slug === slug2)) {
+            existingIndex.competitors.push({
+              slug: slug2, name, domain, totalArticles: 0, lastScanAt: "",
+              newSinceLastScan: 0, topClusters: [], recentHighlight: "Just added — run a scan to index articles",
+            });
+            existingIndex.updatedAt = new Date().toISOString();
+            memory2.save("areas/competitors/_index.json", existingIndex, "onboarding");
+          }
+
+          // Mark all phases complete
+          for (const phase of ["discover-sitemap", "test-extraction", "create-profile"]) {
+            runStore.updatePhase(run.id, phase, { status: "completed", completedAt: new Date().toISOString() });
+          }
+          runStore.update(run.id, { status: "completed", completedAt: new Date().toISOString() });
+        } catch (err) {
+          log.error({ err }, "onboarding failed");
+          runStore.update(run.id, { status: "failed", completedAt: new Date().toISOString(), error: String(err) });
+        }
+      })();
+
+      return { message: "Onboarding started", runId: run.id };
+    },
+  );
 }

--- a/backend/src/api/routes/cmo.ts
+++ b/backend/src/api/routes/cmo.ts
@@ -212,8 +212,29 @@ export async function cmoRoutes(app: FastifyInstance) {
     async (request) => {
       const { customerId, projectId } = request.params;
       const memory = app.ctx.memoryFor(customerId, projectId);
-      const index = memory.load("areas/competitors/_index.json");
+      let index = memory.load<{ competitors: Array<Record<string, unknown>> }>("areas/competitors/_index.json");
       const gapMatrix = memory.load("areas/competitors/_gap-matrix.json");
+
+      // Fallback: if no memory index, build from project settings
+      if (!index || !index.competitors?.length) {
+        const project = app.ctx.projectsFor(customerId).get(projectId);
+        const competitors = project?.competitors ?? [];
+        if (competitors.length > 0) {
+          index = {
+            competitors: competitors.map((c) => ({
+              slug: c.domain.replace(/^https?:\/\//, "").replace(/^www\./, "").replace(/\/$/, "").replace(/\..+$/, "").replace(/[^a-z0-9]/gi, "-").toLowerCase(),
+              name: c.name,
+              domain: c.domain,
+              totalArticles: 0,
+              lastScanAt: "",
+              newSinceLastScan: 0,
+              topClusters: [],
+              recentHighlight: "Not yet scanned",
+            })),
+          };
+        }
+      }
+
       return { index, gapMatrix };
     },
   );

--- a/backend/src/api/routes/ideas.ts
+++ b/backend/src/api/routes/ideas.ts
@@ -1,0 +1,66 @@
+import type { FastifyInstance } from "fastify";
+import type { Idea } from "../../models/idea.js";
+
+export async function ideaRoutes(app: FastifyInstance) {
+  // GET /ideas
+  app.get<{ Params: { customerId: string; projectId: string } }>(
+    "/",
+    async (request) => {
+      const { customerId, projectId } = request.params;
+      return app.ctx.ideasFor(customerId, projectId).list()
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+  );
+
+  // POST /ideas
+  app.post<{
+    Params: { customerId: string; projectId: string };
+    Body: { title: string; description?: string; labels?: string[] };
+  }>(
+    "/",
+    async (request) => {
+      const { customerId, projectId } = request.params;
+      const { title, description, labels } = request.body as { title?: string; description?: string; labels?: string[] };
+      if (!title?.trim()) return { error: "Title required" };
+
+      const now = new Date().toISOString();
+      return app.ctx.ideasFor(customerId, projectId).create({
+        title: title.trim(),
+        description: description?.trim() ?? "",
+        labels: labels ?? [],
+        attachments: [],
+        status: "inbox",
+        createdAt: now,
+        updatedAt: now,
+      } as Omit<Idea, "id">);
+    },
+  );
+
+  // PATCH /ideas/:ideaId
+  app.patch<{
+    Params: { customerId: string; projectId: string; ideaId: string };
+    Body: Partial<Idea>;
+  }>(
+    "/:ideaId",
+    async (request, reply) => {
+      const { customerId, projectId, ideaId } = request.params;
+      const store = app.ctx.ideasFor(customerId, projectId);
+      const existing = store.get(ideaId);
+      if (!existing) return reply.status(404).send({ error: "Idea not found" });
+
+      const updates = request.body as Partial<Idea>;
+      return store.update(ideaId, { ...updates, updatedAt: new Date().toISOString() });
+    },
+  );
+
+  // DELETE /ideas/:ideaId
+  app.delete<{ Params: { customerId: string; projectId: string; ideaId: string } }>(
+    "/:ideaId",
+    async (request, reply) => {
+      const { customerId, projectId, ideaId } = request.params;
+      const deleted = app.ctx.ideasFor(customerId, projectId).delete(ideaId);
+      if (!deleted) return reply.status(404).send({ error: "Idea not found" });
+      return { message: "Deleted" };
+    },
+  );
+}

--- a/backend/src/api/routes/projects.ts
+++ b/backend/src/api/routes/projects.ts
@@ -126,7 +126,33 @@ export async function projectRoutes(app: FastifyInstance) {
         return reply.status(404).send({ error: "Project not found" });
       }
 
-      const { id: _id, customerId: _cid, createdAt: _ca, ...allowed } = request.body as Record<string, unknown>;
+      const body = request.body as Record<string, unknown>;
+
+      // Handle competitor operations
+      if (body.addCompetitor) {
+        const comp = body.addCompetitor as { domain: string; name: string; notes?: string };
+        const competitors = [...(existing.competitors ?? [])];
+        if (!competitors.some((c) => c.domain === comp.domain)) {
+          competitors.push({ domain: comp.domain, name: comp.name, notes: comp.notes ?? "" });
+        }
+        return store.update(projectId, { competitors, updatedAt: new Date().toISOString() } as Partial<typeof existing>);
+      }
+
+      if (body.removeCompetitorDomain) {
+        const domain = body.removeCompetitorDomain as string;
+        const competitors = (existing.competitors ?? []).filter((c) => c.domain !== domain);
+        return store.update(projectId, { competitors, updatedAt: new Date().toISOString() } as Partial<typeof existing>);
+      }
+
+      if (body.updateCompetitor) {
+        const { oldDomain, domain, name } = body.updateCompetitor as { oldDomain: string; domain: string; name: string };
+        const competitors = (existing.competitors ?? []).map((c) =>
+          c.domain === oldDomain ? { ...c, domain, name } : c,
+        );
+        return store.update(projectId, { competitors, updatedAt: new Date().toISOString() } as Partial<typeof existing>);
+      }
+
+      const { id: _id, customerId: _cid, createdAt: _ca, ...allowed } = body;
       const updated = store.update(projectId, {
         ...allowed,
         updatedAt: new Date().toISOString(),

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -11,6 +11,7 @@ import { PipelineRunStore } from "../models/pipeline-run.js";
 import { TopicStore } from "../models/topic.js";
 import { JobStore } from "../models/job.js";
 import { MemoryStore } from "../models/memory.js";
+import { IdeaStore } from "../models/idea.js";
 import { healthRoutes } from "./routes/health.js";
 import { customerRoutes } from "./routes/customers.js";
 import { projectRoutes } from "./routes/projects.js";
@@ -27,6 +28,7 @@ import { connectorRoutes } from "./routes/connectors.js";
 import { cmoRoutes } from "./routes/cmo.js";
 import { jobRoutes } from "./routes/jobs.js";
 import { heartbeatRoutes } from "./routes/heartbeat.js";
+import { ideaRoutes } from "./routes/ideas.js";
 
 const log = createLogger("server");
 
@@ -41,6 +43,7 @@ export interface AppContext {
   topicsFor(customerId: string, projectId: string): TopicStore;
   jobsFor(customerId: string, projectId: string): JobStore;
   memoryFor(customerId: string, projectId: string): MemoryStore;
+  ideasFor(customerId: string, projectId: string): IdeaStore;
 }
 
 declare module "fastify" {
@@ -85,6 +88,9 @@ export async function buildServer(dataDir: string) {
     memoryFor(customerId: string, projectId: string) {
       return new MemoryStore(path.join(dataDir, "customers", customerId, "projects", projectId));
     },
+    ideasFor(customerId: string, projectId: string) {
+      return new IdeaStore(path.join(dataDir, "customers", customerId, "projects", projectId, "ideas"));
+    },
   };
   app.decorate("ctx", ctx);
 
@@ -107,6 +113,7 @@ export async function buildServer(dataDir: string) {
   await app.register(cmoRoutes, { prefix: "/customers/:customerId/projects/:projectId/cmo" });
   await app.register(jobRoutes, { prefix: "/customers/:customerId/projects/:projectId/jobs" });
   await app.register(heartbeatRoutes, { prefix: "/customers/:customerId/projects/:projectId/heartbeat" });
+  await app.register(ideaRoutes, { prefix: "/customers/:customerId/projects/:projectId/ideas" });
 
   // Error handler
   app.setErrorHandler((error: Error & { statusCode?: number }, _request, reply) => {

--- a/backend/src/models/idea.ts
+++ b/backend/src/models/idea.ts
@@ -1,0 +1,35 @@
+import { Store } from "./store.js";
+
+export interface Idea {
+  id: string;
+  title: string;
+  description?: string;
+  labels: string[]; // "article", "linkedin", "instagram", "x", "tiktok", "newsletter"
+  attachments: IdeaAttachment[];
+  status: "inbox" | "planned" | "done" | "archived";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IdeaAttachment {
+  id: string;
+  type: "link" | "image" | "video" | "file" | "note";
+  url?: string;
+  fileName?: string;
+  content?: string;
+  createdAt: string;
+}
+
+export class IdeaStore extends Store<Idea> {
+  constructor(basePath: string) {
+    super(basePath, "idea.json");
+  }
+
+  listByStatus(status: Idea["status"]): Idea[] {
+    return this.list().filter((i) => i.status === status);
+  }
+
+  listInbox(): Idea[] {
+    return this.listByStatus("inbox");
+  }
+}

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -974,6 +974,7 @@ export interface CompetitorArticle {
   discoveredAt: string;
   topicCluster: string | null;
   h2Headings: string[];
+  h3Headings?: string[];
   estimatedWordCount: number | null;
   hasBeenAnalyzed: boolean;
 }

--- a/backend/src/services/crawl-profiler.ts
+++ b/backend/src/services/crawl-profiler.ts
@@ -63,11 +63,17 @@ export async function analyzeCompetitor(
   const memory = new MemoryStore(projectDir);
   const now = new Date().toISOString();
 
+  // Normalize domain — ensure https:// prefix
+  if (!domain.startsWith("http://") && !domain.startsWith("https://")) {
+    domain = `https://${domain}`;
+  }
+  domain = domain.replace(/\/$/, "");
+
   log.info({ domain, name }, "analyzing competitor site structure");
   emit({ step: "discover-sitemap", status: "running", detail: `Searching for sitemap on ${domain}` });
 
   // ── Step 1: Discover sitemap ────────────────────────────
-  const sitemapUrl = await discoverSitemapUrl(domain);
+  let sitemapUrl = await discoverSitemapUrl(domain);
   let sitemapEntries: Array<{ url: string; lastmod?: string }> = [];
   if (sitemapUrl) {
     sitemapEntries = await fetchSitemap(sitemapUrl);
@@ -144,10 +150,94 @@ export async function analyzeCompetitor(
     articleUrls.push(...longPathUrls);
   }
 
+  // ── Fallback: if no articles from sitemap, crawl the website for blog links ──
+  if (articleUrls.length === 0) {
+    emit({ step: "discover-blog", status: "running", detail: "No articles in sitemap — scanning website for blog links" });
+
+    try {
+      const { chromium: chr } = await import("playwright");
+      const fb = await chr.launch({ headless: true });
+      const fbCtx = await fb.newContext({ userAgent: "FlowBoost/1.0 (content research bot)" });
+      const fbPage = await fbCtx.newPage();
+      await fbPage.goto(domain, { waitUntil: "domcontentloaded", timeout: 15000 });
+      await fbPage.waitForTimeout(2000);
+
+      // Find blog-like links on the page
+      const blogLinks = await fbPage.evaluate(() => {
+        const links = [...document.querySelectorAll("a[href]")] as HTMLAnchorElement[];
+        const blogPatterns = /blog|artikel|articles|news|journal|magazine|beitr|posts|stories|ratgeber|magazin/i;
+        return links
+          .map((a: HTMLAnchorElement) => ({ href: a.href, text: a.textContent?.trim() ?? "" }))
+          .filter((l) => blogPatterns.test(l.href) || blogPatterns.test(l.text))
+          .filter((l) => l.href.startsWith("http"))
+          .slice(0, 10);
+      });
+
+      await fb.close();
+
+      if (blogLinks.length > 0) {
+        emit({ step: "discover-blog", status: "done", detail: `Found ${blogLinks.length} blog links: ${blogLinks.map((l) => l.text || l.href).join(", ").slice(0, 100)}` });
+
+        // Try to find a blog section sitemap from discovered links
+        for (const link of blogLinks) {
+          try {
+            const blogBase = new URL(link.href).origin + new URL(link.href).pathname.replace(/\/$/, "");
+            const blogSitemapCandidates = [
+              `${blogBase}/sitemap.xml`,
+              `${blogBase}/sitemap_index.xml`,
+              `${blogBase}/feed`,
+            ];
+            for (const candidate of blogSitemapCandidates) {
+              const res = await fetch(candidate, { signal: AbortSignal.timeout(5000) });
+              if (res.ok) {
+                const text = await res.text();
+                if (text.includes("<urlset") || text.includes("<sitemapindex")) {
+                  emit({ step: "discover-blog", status: "done", detail: `Blog sitemap found: ${candidate}` });
+                  // Re-run sitemap discovery with the blog URL
+                  const blogEntries = await fetchSitemap(candidate);
+                  if (blogEntries.length > 0) {
+                    sitemapEntries = blogEntries;
+                    sitemapUrl = candidate;
+                    // Re-pick sample articles
+                    const blogArticleUrls = blogEntries
+                      .filter((e) => !/privacy|terms|legal|about|contact/i.test(e.url))
+                      .slice(0, 3)
+                      .map((e) => e.url);
+                    articleUrls.push(...blogArticleUrls);
+                  }
+                  break;
+                }
+              }
+            }
+            if (articleUrls.length > 0) break;
+          } catch { /* try next */ }
+        }
+
+        // If still no sitemap articles, crawl the blog links directly as samples
+        if (articleUrls.length === 0) {
+          for (const link of blogLinks.slice(0, 5)) {
+            try {
+              // Follow the link and look for article links on that page
+              const blogPage = await fbCtx?.newPage().catch(() => null);
+              if (!blogPage) break;
+              // Just use the blog links themselves as samples
+              articleUrls.push(link.href);
+              if (articleUrls.length >= 3) break;
+            } catch { /* skip */ }
+          }
+        }
+      } else {
+        emit({ step: "discover-blog", status: "error", detail: "No blog section found on website" });
+      }
+    } catch (err) {
+      emit({ step: "discover-blog", status: "error", detail: `Website scan failed: ${String(err).slice(0, 100)}` });
+    }
+  }
+
   if (articleUrls.length === 0) {
     log.warn({ domain }, "no sample articles found");
-    emit({ step: "complete", status: "error", detail: "No sample articles found" });
-    return createEmptyProfile(domain, name, sitemapUrl, sitemapEntries.length);
+    emit({ step: "complete", status: "error", detail: "No blog articles found — this site may not have a blog" });
+    return createEmptyProfile(domain, name, sitemapUrl ?? null, sitemapEntries.length);
   }
 
   emit({ step: "test-extraction", status: "running", detail: `Testing ${articleUrls.length} sample articles` });

--- a/backend/src/services/crawl-profiler.ts
+++ b/backend/src/services/crawl-profiler.ts
@@ -45,16 +45,26 @@ export interface CrawlProfile {
  * Analyze a competitor website and create a crawl profile.
  * Uses Playwright to render pages in a real browser and validate extraction.
  */
+export interface ProfileEvent {
+  step: string;
+  status: "running" | "done" | "error";
+  detail?: string;
+  data?: Record<string, unknown>;
+}
+
 export async function analyzeCompetitor(
   domain: string,
   name: string,
   projectDir: string,
+  onEvent?: (event: ProfileEvent) => void,
 ): Promise<CrawlProfile> {
+  const emit = onEvent ?? (() => {});
   const slug = domain.replace(/^https?:\/\//, "").replace(/^www\./, "").replace(/\/$/, "").replace(/\..+$/, "").replace(/[^a-z0-9]/gi, "-").toLowerCase();
   const memory = new MemoryStore(projectDir);
   const now = new Date().toISOString();
 
   log.info({ domain, name }, "analyzing competitor site structure");
+  emit({ step: "discover-sitemap", status: "running", detail: `Searching for sitemap on ${domain}` });
 
   // ── Step 1: Discover sitemap ────────────────────────────
   const sitemapUrl = await discoverSitemapUrl(domain);
@@ -103,6 +113,17 @@ export async function analyzeCompetitor(
     }
   } catch { /* no blog subdomain */ }
 
+  if (sitemapUrl) {
+    emit({ step: "discover-sitemap", status: "done", detail: sitemapUrl, data: { urlCount: sitemapEntries.length, blogPathFilter } });
+  } else {
+    emit({ step: "discover-sitemap", status: "error", detail: "No sitemap found" });
+  }
+
+  if (blogPathFilter) {
+    const filteredCount = sitemapEntries.filter((e) => e.url.includes(blogPathFilter)).length;
+    emit({ step: "detect-blog-path", status: "done", detail: `${blogPathFilter} → ${filteredCount} article URLs`, data: { blogPathFilter, filteredCount } });
+  }
+
   log.info({ sitemapUrl, blogPathFilter, totalUrls: sitemapEntries.length }, "sitemap analysis done");
 
   // ── Step 2: Pick 3 sample article URLs ──────────────────
@@ -125,8 +146,11 @@ export async function analyzeCompetitor(
 
   if (articleUrls.length === 0) {
     log.warn({ domain }, "no sample articles found");
+    emit({ step: "complete", status: "error", detail: "No sample articles found" });
     return createEmptyProfile(domain, name, sitemapUrl, sitemapEntries.length);
   }
+
+  emit({ step: "test-extraction", status: "running", detail: `Testing ${articleUrls.length} sample articles` });
 
   // ── Step 3: Crawl samples with code + validate with Playwright ──
   const samples: CrawlProfile["validation"]["samples"] = [];
@@ -139,7 +163,9 @@ export async function analyzeCompetitor(
     browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({ userAgent: "FlowBoost/1.0 (content research bot)" });
 
-    for (const url of articleUrls) {
+    for (let si = 0; si < articleUrls.length; si++) {
+      const url = articleUrls[si];
+      emit({ step: "analyze-sample", status: "running", detail: `Sample ${si + 1}/${articleUrls.length}: ${url.split("/").pop()}` });
       log.info({ url }, "analyzing sample article");
 
       // Code-based extraction
@@ -204,6 +230,13 @@ export async function analyzeCompetitor(
           wordCount: browserWords,
           h2Count: browserH2s || browserH3s,
           validated,
+        });
+
+        emit({
+          step: "analyze-sample",
+          status: "done",
+          detail: `"${browserData.title.slice(0, 50)}" — ${browserWords} words, ${browserH2s || browserH3s} sections`,
+          data: { url, title: browserData.title, wordCount: browserWords, h2Count: browserH2s, readabilityOk, validated },
         });
 
         log.info({
@@ -281,6 +314,13 @@ export async function analyzeCompetitor(
       confidence: allValidated && samples.length >= 2 ? "high" : samples.length >= 1 ? "medium" : "low",
     },
   };
+
+  emit({
+    step: "profile-created",
+    status: "done",
+    detail: `Method: ${profile.extraction.method}, Confidence: ${profile.validation.confidence}`,
+    data: { method: profile.extraction.method, confidence: profile.validation.confidence, avgWordCount, avgH2Count },
+  });
 
   // Save the profile
   const profileDir = `areas/competitors/${slug}`;

--- a/backend/src/services/sitemap-crawler.ts
+++ b/backend/src/services/sitemap-crawler.ts
@@ -58,7 +58,12 @@ export interface CrawledPage {
  * Tries common patterns: /sitemap.xml, /blog/sitemap.xml, /post-sitemap.xml
  */
 export async function discoverSitemapUrl(blogUrl: string): Promise<string | null> {
-  const base = blogUrl.replace(/\/$/, "");
+  // Normalize URL
+  let normalizedUrl = blogUrl;
+  if (!normalizedUrl.startsWith("http://") && !normalizedUrl.startsWith("https://")) {
+    normalizedUrl = `https://${normalizedUrl}`;
+  }
+  const base = normalizedUrl.replace(/\/$/, "");
   const domain = new URL(base).origin;
   const hostname = new URL(base).hostname;
 
@@ -230,9 +235,10 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
     const domH2s = [...contentRoot.querySelectorAll("h2")]
       .map((el) => decodeHtmlEntities(el.textContent?.trim() ?? ""))
       .filter((h) => h.length > 3 && h.length < 200 && !(h === h.toUpperCase() && h.split(/\s+/).length <= 2));
+    const h2Set = new Set(domH2s.map((h) => h.toLowerCase()));
     const domH3s = [...contentRoot.querySelectorAll("h3")]
       .map((el) => decodeHtmlEntities(el.textContent?.trim() ?? ""))
-      .filter((h) => h.length > 3 && h.length < 200);
+      .filter((h) => h.length > 3 && h.length < 200 && !h2Set.has(h.toLowerCase()));
 
     // ── Use Readability for content + word count ─────────
     const readabilityWordCount = article?.textContent
@@ -264,9 +270,10 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
       h2Headings = [...articleDom2.window.document.querySelectorAll("h2")]
         .map((el) => decodeHtmlEntities(el.textContent?.trim() ?? ""))
         .filter((h) => h.length > 3 && h.length < 200);
+      const rH2Set = new Set(h2Headings.map((h) => h.toLowerCase()));
       h3Headings = [...articleDom2.window.document.querySelectorAll("h3")]
         .map((el) => decodeHtmlEntities(el.textContent?.trim() ?? ""))
-        .filter((h) => h.length > 3 && h.length < 200);
+        .filter((h) => h.length > 3 && h.length < 200 && !rH2Set.has(h.toLowerCase()));
     } else {
       h2Headings = domH2s;
       h3Headings = domH3s;

--- a/backend/src/services/sitemap-crawler.ts
+++ b/backend/src/services/sitemap-crawler.ts
@@ -67,13 +67,16 @@ export async function discoverSitemapUrl(blogUrl: string): Promise<string | null
 
   const candidates = [
     `${blogSubdomain}/sitemap.xml`,
-    `${base}/blog/sitemap.xml`,
+    `${domain}/blog/sitemap_index.xml`,
     `${domain}/blog/sitemap.xml`,
+    `${domain}/blog/post-sitemap.xml`,
+    `${domain}/blog/wp-sitemap-posts-post-1.xml`,
     `${base}/sitemap.xml`,
     `${domain}/sitemap.xml`,
     `${domain}/post-sitemap.xml`,
     `${domain}/sitemap_index.xml`,
     `${domain}/articles/sitemap.xml`,
+    `${domain}/wp-sitemap.xml`,
   ];
 
   for (const url of candidates) {

--- a/backend/src/services/sitemap-crawler.ts
+++ b/backend/src/services/sitemap-crawler.ts
@@ -51,6 +51,7 @@ export interface CrawledPage {
   metaDescription?: string;
   author?: string;
   publishedAt?: string;
+  category?: string;
 }
 
 /**
@@ -199,6 +200,7 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
     let jsonLdDate: string | undefined;
     let jsonLdWordCount: number | undefined;
     let jsonLdAuthor: string | undefined;
+    let extractedCategory: string | undefined;
 
     const jsonLdMatches = html.match(/<script\s+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi);
     if (jsonLdMatches) {
@@ -216,6 +218,10 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
             jsonLdWordCount = article.wordCount as number | undefined;
             jsonLdAuthor = typeof article.author === "string" ? article.author
               : (article.author as Record<string, unknown>)?.name as string | undefined;
+            // Category from JSON-LD
+            if (article.articleSection) extractedCategory = String(article.articleSection);
+            else if (article.genre) extractedCategory = String(article.genre);
+            else if (Array.isArray(article.keywords) && article.keywords.length > 0) extractedCategory = String(article.keywords[0]);
           }
         } catch { /* malformed JSON-LD */ }
       }
@@ -225,6 +231,55 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
     const dom = new JSDOM(html, { url });
     const reader = new Readability(dom.window.document);
     const article = reader.parse();
+
+    // ── Extract category from page ──────────────────────────
+    if (!extractedCategory) {
+      // Try meta tags
+      const articleSection = html.match(/<meta\s+property="article:section"\s+content="([^"]*)"/) ??
+        html.match(/<meta\s+content="([^"]*)"\s+property="article:section"/);
+      if (articleSection) extractedCategory = articleSection[1];
+    }
+    if (!extractedCategory) {
+      // Try WordPress category tags (rel="category tag" or rel="category")
+      const wpCategory = html.match(/<a[^>]*rel="category[^"]*"[^>]*>([^<]+)<\/a>/i);
+      if (wpCategory) extractedCategory = wpCategory[1].trim();
+    }
+    if (!extractedCategory) {
+      // Try elements with "category" in class name (Squarespace, custom themes)
+      const catElements = html.match(/<(?:a|span|div)[^>]*class="[^"]*category[^"]*"[^>]*>([^<]{2,50})<\/(?:a|span|div)>/gi) ?? [];
+      for (const el of catElements) {
+        const text = el.replace(/<[^>]+>/g, "").trim();
+        // Skip template variables and very long texts (descriptions, not categories)
+        if (text && text.length > 1 && text.length < 40 && !text.startsWith("$") && !text.includes("{")) {
+          extractedCategory = text;
+          break;
+        }
+      }
+    }
+    if (!extractedCategory) {
+      // Try breadcrumbs
+      const breadcrumb = html.match(/<nav[^>]*class="[^"]*breadcrumb[^"]*"[^>]*>([\s\S]*?)<\/nav>/i);
+      if (breadcrumb) {
+        const crumbLinks = breadcrumb[1].match(/<a[^>]*>([^<]+)<\/a>/gi) ?? [];
+        // Take the last crumb before the article title (usually the category)
+        if (crumbLinks.length >= 3) {
+          const cat = crumbLinks[crumbLinks.length - 2].replace(/<[^>]+>/g, "").trim();
+          if (cat && cat.length > 1 && cat.length < 50) extractedCategory = cat;
+        }
+      }
+    }
+    if (!extractedCategory) {
+      // Try URL path — e.g., /blog/category/sleep/article-slug → "sleep"
+      const pathParts = new URL(url).pathname.split("/").filter(Boolean);
+      if (pathParts.length >= 3) {
+        // Common patterns: /blog/category/article, /blog/topic/article
+        const possibleCat = pathParts[pathParts.length - 2];
+        // Skip generic path segments
+        if (possibleCat && !/^(blog|articles|posts|page|\d+)$/i.test(possibleCat)) {
+          extractedCategory = possibleCat.replace(/-/g, " ");
+        }
+      }
+    }
 
     // ── Extract headings from full DOM (jsdom, not regex) ───
     // This works better than Readability for some sites (React SPAs)
@@ -300,6 +355,7 @@ export async function crawlPage(url: string): Promise<CrawledPage | null> {
       metaDescription: article?.excerpt ?? undefined,
       author: jsonLdAuthor ?? article?.byline ?? undefined,
       publishedAt: jsonLdDate,
+      category: extractedCategory ? decodeHtmlEntities(extractedCategory) : undefined,
     };
   } catch (err) {
     log.warn({ url, err }, "page crawl failed");

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Inbox,
+  Plus,
+  Loader2,
+  Trash2,
+  MoreHorizontal,
+  Tag,
+  Archive,
+  Check,
+} from "lucide-react";
+import { useProject } from "@/lib/project-context";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:6100";
+
+const LABELS = [
+  { key: "article", label: "Article", color: "bg-blue-100 text-blue-700" },
+  { key: "linkedin", label: "LinkedIn", color: "bg-sky-100 text-sky-700" },
+  { key: "instagram", label: "Instagram", color: "bg-pink-100 text-pink-700" },
+  { key: "x", label: "X", color: "bg-gray-100 text-gray-700" },
+  { key: "tiktok", label: "TikTok", color: "bg-purple-100 text-purple-700" },
+  { key: "newsletter", label: "Newsletter", color: "bg-amber-100 text-amber-700" },
+];
+
+interface Idea {
+  id: string;
+  title: string;
+  description?: string;
+  labels: string[];
+  status: string;
+  createdAt: string;
+}
+
+export default function InboxPage() {
+  const { customerId, projectId, loading: projectLoading } = useProject();
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newTitle, setNewTitle] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const loadIdeas = useCallback(async () => {
+    if (!customerId || !projectId) return;
+    try {
+      const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/ideas`);
+      if (res.ok) setIdeas(await res.json());
+    } catch { /* ignore */ }
+    finally { setLoading(false); }
+  }, [customerId, projectId]);
+
+  useEffect(() => { loadIdeas(); }, [loadIdeas]);
+
+  const addIdea = async () => {
+    if (!customerId || !projectId || !newTitle.trim()) return;
+    setAdding(true);
+    try {
+      const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/ideas`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: newTitle.trim(), description: newDescription.trim() || undefined }),
+      });
+      if (res.ok) {
+        setNewTitle("");
+        setNewDescription("");
+        loadIdeas();
+      }
+    } catch { /* ignore */ }
+    finally { setAdding(false); }
+  };
+
+  const toggleLabel = async (ideaId: string, label: string) => {
+    if (!customerId || !projectId) return;
+    const idea = ideas.find((i) => i.id === ideaId);
+    if (!idea) return;
+    const labels = idea.labels.includes(label)
+      ? idea.labels.filter((l) => l !== label)
+      : [...idea.labels, label];
+    await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/ideas/${ideaId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    });
+    loadIdeas();
+  };
+
+  const archiveIdea = async (ideaId: string) => {
+    if (!customerId || !projectId) return;
+    await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/ideas/${ideaId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "archived" }),
+    });
+    loadIdeas();
+  };
+
+  const deleteIdea = async (ideaId: string) => {
+    if (!customerId || !projectId) return;
+    await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/ideas/${ideaId}`, {
+      method: "DELETE",
+    });
+    loadIdeas();
+  };
+
+  if (projectLoading || loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>;
+  }
+
+  const inboxIdeas = ideas.filter((i) => i.status === "inbox");
+  const archivedIdeas = ideas.filter((i) => i.status === "archived");
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2"><Inbox className="h-6 w-6" />Inbox</h1>
+        <p className="text-sm text-muted-foreground">Collect ideas, links, notes — the CMO can use these for content planning.</p>
+      </div>
+
+      {/* Add Idea */}
+      <div className="rounded-xl border bg-background shadow-sm p-4 space-y-3">
+        <Input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter" && newTitle.trim()) addIdea(); }}
+          placeholder="Add an idea..."
+          className="border-0 shadow-none text-sm px-0 focus-visible:ring-0"
+        />
+        {newTitle.trim() && (
+          <>
+            <Input
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              placeholder="Description (optional)"
+              className="border-0 shadow-none text-xs px-0 focus-visible:ring-0 text-muted-foreground"
+            />
+            <div className="flex justify-end">
+              <Button size="sm" onClick={addIdea} disabled={adding || !newTitle.trim()}>
+                {adding ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-1.5 h-3.5 w-3.5" />}
+                Add
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Ideas List */}
+      {inboxIdeas.length === 0 ? (
+        <div className="rounded-xl border-2 border-dashed p-8 text-center">
+          <Inbox className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" />
+          <p className="text-sm font-medium">Inbox is empty</p>
+          <p className="text-xs text-muted-foreground">Add ideas, links, or notes for future content.</p>
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-background shadow-sm divide-y">
+          {inboxIdeas.map((idea) => (
+            <div key={idea.id} className="flex items-start gap-3 px-4 py-3 group">
+              <button
+                type="button"
+                onClick={() => archiveIdea(idea.id)}
+                className="mt-1 shrink-0 h-5 w-5 rounded-full border-2 border-muted-foreground/30 hover:border-emerald-500 hover:bg-emerald-50 flex items-center justify-center transition-colors"
+                title="Mark as done"
+              >
+                <Check className="h-3 w-3 text-transparent group-hover:text-emerald-500" />
+              </button>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm">{idea.title}</p>
+                {idea.description && <p className="text-xs text-muted-foreground mt-0.5">{idea.description}</p>}
+                {idea.labels.length > 0 && (
+                  <div className="flex gap-1 mt-1.5">
+                    {idea.labels.map((l) => {
+                      const label = LABELS.find((lb) => lb.key === l);
+                      return label ? (
+                        <Badge key={l} variant="secondary" className={`text-[10px] ${label.color}`}>{label.label}</Badge>
+                      ) : null;
+                    })}
+                  </div>
+                )}
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="p-1 rounded-md hover:bg-muted text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {LABELS.map((l) => (
+                    <DropdownMenuItem key={l.key} onClick={() => toggleLabel(idea.id, l.key)}>
+                      <Tag className="mr-2 h-3.5 w-3.5" />
+                      {l.label}
+                      {idea.labels.includes(l.key) && <Check className="ml-auto h-3.5 w-3.5" />}
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuItem onClick={() => archiveIdea(idea.id)}>
+                    <Archive className="mr-2 h-3.5 w-3.5" />Archive
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className="text-destructive" onClick={() => deleteIdea(idea.id)}>
+                    <Trash2 className="mr-2 h-3.5 w-3.5" />Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Archived */}
+      {archivedIdeas.length > 0 && (
+        <div className="text-xs text-muted-foreground pt-4">
+          {archivedIdeas.length} archived idea{archivedIdeas.length !== 1 ? "s" : ""}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/intelligence/competitors/page.tsx
+++ b/frontend/src/app/intelligence/competitors/page.tsx
@@ -6,6 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Loader2,
   Users,
   ExternalLink,
@@ -15,6 +22,10 @@ import {
   Globe,
   Plus,
   RefreshCw,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  RotateCcw,
 } from "lucide-react";
 import { useProject } from "@/lib/project-context";
 import { getCompetitors, getCompetitorDetail, triggerMonitor } from "@/lib/api";
@@ -37,6 +48,12 @@ export default function CompetitorsPage() {
   const [addDomain, setAddDomain] = useState("");
   const [addName, setAddName] = useState("");
   const [adding, setAdding] = useState(false);
+  const [onboardingRunId, setOnboardingRunId] = useState<string | null>(null);
+  const [onboardingEvents, setOnboardingEvents] = useState<Array<{ tool: string; input: string; timestamp: string }>>([]);
+  const [onboardingDone, setOnboardingDone] = useState(false);
+  const [editComp, setEditComp] = useState<{ slug: string; name: string; domain: string } | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDomain, setEditDomain] = useState("");
 
   const loadData = useCallback(async () => {
     if (!customerId || !projectId) return;
@@ -85,36 +102,100 @@ export default function CompetitorsPage() {
   const handleAddCompetitor = async () => {
     if (!customerId || !projectId || !addDomain.trim() || !addName.trim()) return;
     setAdding(true);
+    setOnboardingEvents([]);
+    setOnboardingDone(false);
     try {
       // Add to project settings
-      const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}`, {
-        method: "PATCH",
+      await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}`, {
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           addCompetitor: { domain: addDomain.trim(), name: addName.trim(), notes: "" },
         }),
       });
-      if (res.ok) {
-        setShowAdd(false);
-        setAddDomain("");
-        setAddName("");
-        // Trigger scan for the new competitor
-        await triggerMonitor(customerId, projectId, "competitor-scan");
-        setScanning(true);
-        // Poll for results
-        const poll = setInterval(async () => {
-          const result = await getCompetitors(customerId, projectId);
-          const idx = result.index as { competitors: CompetitorEntry[] } | null;
-          if (idx?.competitors && idx.competitors.length > competitors.length) {
-            setCompetitors(idx.competitors);
-            setScanning(false);
-            clearInterval(poll);
+
+      // Start onboarding analysis
+      const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/onboard`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domain: addDomain.trim(), name: addName.trim() }),
+      });
+      const { runId } = await res.json() as { runId: string };
+      setOnboardingRunId(runId);
+
+      // Poll pipeline run for events
+      const poll = setInterval(async () => {
+        try {
+          const runRes = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/pipeline/runs/${runId}`);
+          if (!runRes.ok) return;
+          const run = await runRes.json() as { status: string; phases: Array<{ agentCalls: Array<{ events?: Array<{ tool: string; input: string; timestamp: string }> }> }> };
+
+          // Collect all events from all phases
+          const events: Array<{ tool: string; input: string; timestamp: string }> = [];
+          for (const phase of run.phases) {
+            for (const call of phase.agentCalls) {
+              if (call.events) events.push(...call.events);
+            }
           }
-        }, 5000);
-        setTimeout(() => { clearInterval(poll); setScanning(false); }, 300000);
-      }
+          setOnboardingEvents(events);
+
+          if (run.status === "completed" || run.status === "failed") {
+            setOnboardingDone(true);
+            setAdding(false);
+            clearInterval(poll);
+            // Add to UI list immediately (memory index isn't updated until next scan)
+            const newComp: CompetitorEntry = {
+              slug: addDomain.trim().replace(/^https?:\/\//, "").replace(/^www\./, "").replace(/\/$/, "").replace(/\..+$/, "").replace(/[^a-z0-9]/gi, "-").toLowerCase(),
+              name: addName.trim(),
+              domain: addDomain.trim(),
+              totalArticles: 0,
+              lastScanAt: "",
+              newSinceLastScan: 0,
+              topClusters: [],
+              recentHighlight: "Just added — run a scan to index articles",
+            };
+            setCompetitors((prev) => prev.some((c) => c.domain === newComp.domain) ? prev : [...prev, newComp]);
+            loadData();
+          }
+        } catch { /* ignore */ }
+      }, 2000);
+      setTimeout(() => { clearInterval(poll); setAdding(false); setOnboardingDone(true); }, 300000);
+    } catch {
+      setAdding(false);
+    }
+  };
+
+  const handleDeleteCompetitor = async (domain: string, slug: string) => {
+    if (!customerId || !projectId) return;
+    try {
+      // Remove from project settings
+      await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ removeCompetitorDomain: domain }),
+      });
+      // Remove from memory (competitor data + update _index.json)
+      await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/${slug}`, {
+        method: "DELETE",
+      });
+      // Remove from UI immediately
+      setCompetitors((prev) => prev.filter((c) => c.domain !== domain));
     } catch { /* ignore */ }
-    finally { setAdding(false); }
+  };
+
+  const handleEditCompetitor = async () => {
+    if (!customerId || !projectId || !editComp) return;
+    try {
+      await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          updateCompetitor: { oldDomain: editComp.domain, domain: editDomain.trim(), name: editName.trim() },
+        }),
+      });
+      setEditComp(null);
+      loadData();
+    } catch { /* ignore */ }
   };
 
   const timeAgo = (iso: string): string => {
@@ -251,15 +332,35 @@ export default function CompetitorsPage() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {competitors.map((c) => (
-            <button
+            <div
               key={c.slug}
-              type="button"
+              className="rounded-xl border bg-background shadow-sm p-5 text-left hover:shadow-md transition-shadow cursor-pointer relative group"
               onClick={() => loadDetail(c.slug)}
-              className="rounded-xl border bg-background shadow-sm p-5 text-left hover:shadow-md transition-shadow"
             >
               <div className="flex items-center justify-between mb-2">
                 <h3 className="text-sm font-semibold">{c.name}</h3>
-                {c.newSinceLastScan > 0 ? <Badge variant="default" className="text-[10px]">+{c.newSinceLastScan} new</Badge> : null}
+                <div className="flex items-center gap-1">
+                  {c.newSinceLastScan > 0 ? <Badge variant="default" className="text-[10px]">+{c.newSinceLastScan} new</Badge> : null}
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button type="button" onClick={(e) => e.stopPropagation()} className="p-1 rounded-md hover:bg-muted text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setEditComp({ slug: c.slug, name: c.name, domain: c.domain }); setEditName(c.name); setEditDomain(c.domain); }}>
+                        <Pencil className="mr-2 h-3.5 w-3.5" />Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={(e) => { e.stopPropagation(); triggerMonitor(customerId!, projectId!, "competitor-scan"); }}>
+                        <RotateCcw className="mr-2 h-3.5 w-3.5" />Re-scan
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-destructive" onClick={(e) => { e.stopPropagation(); handleDeleteCompetitor(c.domain, c.slug); }}>
+                        <Trash2 className="mr-2 h-3.5 w-3.5" />Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
               <p className="text-xs text-muted-foreground mb-3">{c.totalArticles} articles indexed</p>
               {c.topClusters.length > 0 && (
@@ -272,7 +373,7 @@ export default function CompetitorsPage() {
               <p className="text-xs text-muted-foreground flex items-center gap-1">
                 <Clock className="h-3 w-3" />{c.lastScanAt ? timeAgo(c.lastScanAt) : "Never scanned"}
               </p>
-            </button>
+            </div>
           ))}
           {scanning && (
             <div className="rounded-xl border-2 border-dashed p-5 flex items-center justify-center">
@@ -288,29 +389,97 @@ export default function CompetitorsPage() {
       )}
 
       {/* Add Competitor Dialog */}
-      <Dialog open={showAdd} onOpenChange={setShowAdd}>
+      <Dialog open={showAdd} onOpenChange={(open) => { if (!adding) { setShowAdd(open); if (!open) { setOnboardingRunId(null); setOnboardingEvents([]); setOnboardingDone(false); } } }}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{onboardingRunId ? `Analyzing ${addName}` : "Add Competitor"}</DialogTitle>
+          </DialogHeader>
+
+          {!onboardingRunId ? (
+            /* Form */
+            <>
+              <div className="space-y-4">
+                <div>
+                  <label className="text-sm font-medium mb-1.5 block">Name</label>
+                  <Input value={addName} onChange={(e) => setAddName(e.target.value)} placeholder="e.g. Calm" />
+                </div>
+                <div>
+                  <label className="text-sm font-medium mb-1.5 block">Website</label>
+                  <Input value={addDomain} onChange={(e) => setAddDomain(e.target.value)} placeholder="e.g. https://www.calm.com" />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  The system will discover the blog, analyze the site structure with a real browser, and validate content extraction.
+                </p>
+              </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="outline" size="sm" onClick={() => setShowAdd(false)}>Cancel</Button>
+                <Button size="sm" onClick={handleAddCompetitor} disabled={adding || !addDomain.trim() || !addName.trim()}>
+                  {adding ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-1.5 h-3.5 w-3.5" />}
+                  Add & Analyze
+                </Button>
+              </div>
+            </>
+          ) : (
+            /* Onboarding Progress */
+            <div className="space-y-3">
+              <div className="space-y-2 max-h-[400px] overflow-y-auto">
+                {onboardingEvents.map((ev, i) => {
+                  const isLast = i === onboardingEvents.length - 1;
+                  const icon = ev.tool === "discover-sitemap" ? "🔍"
+                    : ev.tool === "detect-blog-path" ? "📂"
+                    : ev.tool === "analyze-sample" ? "📄"
+                    : ev.tool === "profile-created" ? "✅"
+                    : "⚙️";
+                  return (
+                    <div key={i} className="flex items-start gap-2 text-sm">
+                      <span className="shrink-0 mt-0.5">{icon}</span>
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-xs ${isLast && !onboardingDone ? "text-foreground font-medium" : "text-muted-foreground"}`}>
+                          {ev.input}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+                {adding && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                    <span className="text-xs text-muted-foreground">Analyzing...</span>
+                  </div>
+                )}
+              </div>
+              {onboardingDone && (
+                <div className="flex justify-end gap-2 pt-2 border-t">
+                  <Button variant="outline" size="sm" onClick={() => { setShowAdd(false); setOnboardingRunId(null); setOnboardingEvents([]); setOnboardingDone(false); setAddDomain(""); setAddName(""); }}>
+                    Close
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Competitor Dialog */}
+      <Dialog open={!!editComp} onOpenChange={(open) => { if (!open) setEditComp(null); }}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Add Competitor</DialogTitle>
+            <DialogTitle>Edit Competitor</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium mb-1.5 block">Name</label>
-              <Input value={addName} onChange={(e) => setAddName(e.target.value)} placeholder="e.g. Calm" />
+              <Input value={editName} onChange={(e) => setEditName(e.target.value)} />
             </div>
             <div>
               <label className="text-sm font-medium mb-1.5 block">Website</label>
-              <Input value={addDomain} onChange={(e) => setAddDomain(e.target.value)} placeholder="e.g. https://www.calm.com" />
+              <Input value={editDomain} onChange={(e) => setEditDomain(e.target.value)} />
             </div>
-            <p className="text-xs text-muted-foreground">
-              The system will automatically discover the blog, analyze the site structure, and start indexing articles.
-            </p>
           </div>
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" size="sm" onClick={() => setShowAdd(false)}>Cancel</Button>
-            <Button size="sm" onClick={handleAddCompetitor} disabled={adding || !addDomain.trim() || !addName.trim()}>
-              {adding ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-1.5 h-3.5 w-3.5" />}
-              Add & Analyze
+            <Button variant="outline" size="sm" onClick={() => setEditComp(null)}>Cancel</Button>
+            <Button size="sm" onClick={handleEditCompetitor} disabled={!editName.trim() || !editDomain.trim()}>
+              Save
             </Button>
           </div>
         </DialogContent>

--- a/frontend/src/app/intelligence/competitors/page.tsx
+++ b/frontend/src/app/intelligence/competitors/page.tsx
@@ -33,7 +33,7 @@ import { getCompetitors, getCompetitorDetail, triggerMonitor } from "@/lib/api";
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:6100";
 
 type CompetitorEntry = { slug: string; name: string; domain: string; totalArticles: number; lastScanAt: string; newSinceLastScan: number; topClusters: string[]; recentHighlight: string };
-type ArticleData = { url: string; title: string; topicCluster: string | null; h2Headings: string[]; estimatedWordCount: number | null; publishedAt: string | null };
+type ArticleData = { url: string; title: string; topicCluster: string | null; h2Headings: string[]; h3Headings?: string[]; estimatedWordCount: number | null; publishedAt: string | null };
 type CompetitorDetailData = { profile: Record<string, unknown>; topicCoverage: { clusters: Array<{ cluster: string; articleCount: number; depth: string; trend: string }> }; recentActivity: { newArticles: Array<{ url: string; title: string; topicCluster: string | null }> }; blogStats: { totalArticles: number; lastCrawlAt: string } | null; articles: ArticleData[] };
 
 export default function CompetitorsPage() {
@@ -270,7 +270,7 @@ export default function CompetitorsPage() {
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         {a.topicCluster ? <span className="capitalize">{a.topicCluster.replace(/-/g, " ")}</span> : null}
                         {a.estimatedWordCount ? <span>· {a.estimatedWordCount.toLocaleString()} words</span> : null}
-                        {a.h2Headings?.length > 0 ? <span>· {a.h2Headings.length} sections</span> : null}
+                        {(a.h2Headings?.length > 0 || a.h3Headings?.length) ? <span>· {(a.h2Headings?.length ?? 0) + (a.h3Headings?.length ?? 0)} sections</span> : null}
                       </div>
                     </div>
                     <a href={a.url} target="_blank" rel="noopener noreferrer" className="shrink-0 p-1 hover:bg-muted rounded" onClick={(e) => e.stopPropagation()}>
@@ -279,11 +279,14 @@ export default function CompetitorsPage() {
                   </summary>
                   <div className="px-5 pb-4 pt-1 ml-7 space-y-2">
                     <p className="text-xs text-muted-foreground font-mono truncate">{a.url}</p>
-                    {a.h2Headings?.length > 0 && (
+                    {(a.h2Headings?.length > 0 || a.h3Headings?.length) && (
                       <div className="space-y-1">
-                        <p className="text-xs font-medium text-muted-foreground">H2 Structure:</p>
-                        {a.h2Headings.map((h, j) => (
-                          <p key={j} className="text-xs text-muted-foreground pl-3 border-l-2 border-muted">{h}</p>
+                        <p className="text-xs font-medium text-muted-foreground">Article Structure:</p>
+                        {a.h2Headings?.map((h, j) => (
+                          <p key={`h2-${j}`} className="text-xs text-muted-foreground pl-3 border-l-2 border-foreground/20 font-medium">{h}</p>
+                        ))}
+                        {a.h3Headings?.map((h, j) => (
+                          <p key={`h3-${j}`} className="text-xs text-muted-foreground pl-6 border-l-2 border-muted">{h}</p>
                         ))}
                       </div>
                     )}
@@ -351,7 +354,7 @@ export default function CompetitorsPage() {
                       <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setEditComp({ slug: c.slug, name: c.name, domain: c.domain }); setEditName(c.name); setEditDomain(c.domain); }}>
                         <Pencil className="mr-2 h-3.5 w-3.5" />Edit
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={(e) => { e.stopPropagation(); triggerMonitor(customerId!, projectId!, "competitor-scan"); }}>
+                      <DropdownMenuItem onClick={async (e) => { e.stopPropagation(); await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/${c.slug}/scan`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) }); }}>
                         <RotateCcw className="mr-2 h-3.5 w-3.5" />Re-scan
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />

--- a/frontend/src/app/intelligence/competitors/page.tsx
+++ b/frontend/src/app/intelligence/competitors/page.tsx
@@ -349,7 +349,7 @@ export default function CompetitorsPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2"><Users className="h-6 w-6" />Competitors</h1>
-          <p className="text-sm text-muted-foreground">Track competitor content and find gaps in your coverage.</p>
+          <p className="text-sm text-muted-foreground">Track competitor blogs and articles to find content gaps. Only editorial content is indexed — no product pages or shop listings.</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={() => setShowAdd(true)}>

--- a/frontend/src/app/intelligence/competitors/page.tsx
+++ b/frontend/src/app/intelligence/competitors/page.tsx
@@ -40,6 +40,9 @@ export default function CompetitorsPage() {
   const { customerId, projectId, loading: projectLoading } = useProject();
   const [loading, setLoading] = useState(true);
   const [scanning, setScanning] = useState(false);
+  const [scanRunId, setScanRunId] = useState<string | null>(null);
+  const [scanEvents, setScanEvents] = useState<Array<{ tool: string; input: string }>>([]);
+  const [scanDone, setScanDone] = useState(false);
   const [competitors, setCompetitors] = useState<CompetitorEntry[]>([]);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [detail, setDetail] = useState<CompetitorDetailData | null>(null);
@@ -78,25 +81,54 @@ export default function CompetitorsPage() {
     finally { setDetailLoading(false); }
   };
 
+  const startScanPolling = (runId: string) => {
+    setScanRunId(runId);
+    setScanEvents([]);
+    setScanDone(false);
+    setScanning(true);
+
+    const poll = setInterval(async () => {
+      try {
+        const runRes = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/pipeline/runs/${runId}`);
+        if (!runRes.ok) return;
+        const run = await runRes.json() as { status: string; phases: Array<{ agentCalls: Array<{ events?: Array<{ tool: string; input: string }> }> }> };
+
+        const events: Array<{ tool: string; input: string }> = [];
+        for (const phase of run.phases) {
+          for (const call of phase.agentCalls) {
+            if (call.events) events.push(...call.events);
+          }
+        }
+        setScanEvents(events);
+
+        if (run.status === "completed" || run.status === "failed") {
+          setScanDone(true);
+          setScanning(false);
+          clearInterval(poll);
+          loadData();
+        }
+      } catch { /* ignore */ }
+    }, 2000);
+    setTimeout(() => { clearInterval(poll); setScanning(false); setScanDone(true); }, 300000);
+  };
+
   const handleScan = async () => {
     if (!customerId || !projectId || scanning) return;
-    setScanning(true);
     try {
-      await triggerMonitor(customerId, projectId, "competitor-scan");
-      // Poll until done
-      const poll = setInterval(async () => {
-        try {
-          const result = await getCompetitors(customerId, projectId);
-          const idx = result.index as { competitors: CompetitorEntry[] } | null;
-          if (idx?.competitors && JSON.stringify(idx.competitors) !== JSON.stringify(competitors)) {
-            setCompetitors(idx.competitors);
-            setScanning(false);
-            clearInterval(poll);
-          }
-        } catch { /* ignore */ }
-      }, 5000);
-      setTimeout(() => { clearInterval(poll); setScanning(false); }, 300000);
-    } catch { setScanning(false); }
+      const result = await triggerMonitor(customerId, projectId, "competitor-scan");
+      startScanPolling(result.runId);
+    } catch { /* ignore */ }
+  };
+
+  const handleSingleScan = async (slug: string) => {
+    if (!customerId || !projectId || scanning) return;
+    try {
+      const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/${slug}/scan`, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}),
+      });
+      const { runId } = await res.json() as { runId: string };
+      startScanPolling(runId);
+    } catch { /* ignore */ }
   };
 
   const handleAddCompetitor = async () => {
@@ -104,13 +136,20 @@ export default function CompetitorsPage() {
     setAdding(true);
     setOnboardingEvents([]);
     setOnboardingDone(false);
+
+    // Normalize domain
+    let normalizedDomain = addDomain.trim();
+    if (!normalizedDomain.startsWith("http://") && !normalizedDomain.startsWith("https://")) {
+      normalizedDomain = `https://${normalizedDomain}`;
+    }
+
     try {
       // Add to project settings
       await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          addCompetitor: { domain: addDomain.trim(), name: addName.trim(), notes: "" },
+          addCompetitor: { domain: normalizedDomain, name: addName.trim(), notes: "" },
         }),
       });
 
@@ -118,7 +157,7 @@ export default function CompetitorsPage() {
       const res = await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/onboard`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ domain: addDomain.trim(), name: addName.trim() }),
+        body: JSON.stringify({ domain: normalizedDomain, name: addName.trim() }),
       });
       const { runId } = await res.json() as { runId: string };
       setOnboardingRunId(runId);
@@ -354,7 +393,7 @@ export default function CompetitorsPage() {
                       <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setEditComp({ slug: c.slug, name: c.name, domain: c.domain }); setEditName(c.name); setEditDomain(c.domain); }}>
                         <Pencil className="mr-2 h-3.5 w-3.5" />Edit
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={async (e) => { e.stopPropagation(); await fetch(`${API_URL}/customers/${customerId}/projects/${projectId}/cmo/competitors/${c.slug}/scan`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) }); }}>
+                      <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleSingleScan(c.slug); }}>
                         <RotateCcw className="mr-2 h-3.5 w-3.5" />Re-scan
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
@@ -378,10 +417,33 @@ export default function CompetitorsPage() {
               </p>
             </div>
           ))}
-          {scanning && (
-            <div className="rounded-xl border-2 border-dashed p-5 flex items-center justify-center">
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground mr-2" />
-              <span className="text-sm text-muted-foreground">Scanning...</span>
+          {(scanning || (scanDone && scanEvents.length > 0)) && (
+            <div className="col-span-full rounded-xl border bg-background shadow-sm p-5 space-y-2">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  {scanning ? <Loader2 className="h-4 w-4 animate-spin" /> : <span>✅</span>}
+                  {scanning ? "Scanning..." : "Scan Complete"}
+                </h3>
+                {scanDone && (
+                  <Button variant="ghost" size="sm" className="text-xs" onClick={() => { setScanRunId(null); setScanEvents([]); setScanDone(false); }}>
+                    Close
+                  </Button>
+                )}
+              </div>
+              <div className="max-h-[250px] overflow-y-auto space-y-1">
+                {scanEvents.map((ev, i) => {
+                  const icon = ev.tool.includes("sitemap") ? "🔍" : ev.tool === "diff" ? "📊" : ev.tool.includes("crawl") ? "📄" : ev.tool.includes("index") ? "✅" : ev.tool.includes("gap") ? "📈" : "⚙️";
+                  return (
+                    <p key={i} className="text-xs text-muted-foreground flex items-start gap-1.5">
+                      <span className="shrink-0">{icon}</span>
+                      <span>{ev.input}</span>
+                    </p>
+                  );
+                })}
+                {scanning && scanEvents.length === 0 && (
+                  <p className="text-xs text-muted-foreground">Starting scan...</p>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/app/intelligence/context/page.tsx
+++ b/frontend/src/app/intelligence/context/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Brain, Save, Loader2, Check } from "lucide-react";
+import { useProject } from "@/lib/project-context";
+import { getProjectBrief, getBrandVoice, updateProjectBrief, updateBrandVoice } from "@/lib/api";
+
+type SaveStatus = "idle" | "saving" | "saved";
+
+export default function AIContextPage() {
+  const { customerId, projectId, loading: projectLoading } = useProject();
+  const [projectBrief, setProjectBrief] = useState("");
+  const [brandVoice, setBrandVoice] = useState("");
+  const [briefStatus, setBriefStatus] = useState<SaveStatus>("idle");
+  const [voiceStatus, setVoiceStatus] = useState<SaveStatus>("idle");
+  const [loading, setLoading] = useState(true);
+
+  const loadData = useCallback(async () => {
+    if (!customerId || !projectId) return;
+    try {
+      const [brief, voice] = await Promise.all([
+        getProjectBrief(customerId, projectId),
+        getBrandVoice(customerId),
+      ]);
+      setProjectBrief(brief.content ?? "");
+      setBrandVoice(voice.content ?? "");
+    } catch { /* ignore */ }
+    finally { setLoading(false); }
+  }, [customerId, projectId]);
+
+  useEffect(() => { loadData(); }, [loadData]);
+
+  const saveBrief = async () => {
+    if (!customerId || !projectId) return;
+    setBriefStatus("saving");
+    try {
+      await updateProjectBrief(customerId, projectId, projectBrief);
+      setBriefStatus("saved");
+      setTimeout(() => setBriefStatus("idle"), 2000);
+    } catch { setBriefStatus("idle"); }
+  };
+
+  const saveVoice = async () => {
+    if (!customerId || !projectId) return;
+    setVoiceStatus("saving");
+    try {
+      await updateBrandVoice(customerId, brandVoice);
+      setVoiceStatus("saved");
+      setTimeout(() => setVoiceStatus("idle"), 2000);
+    } catch { setVoiceStatus("idle"); }
+  };
+
+  if (projectLoading || loading) {
+    return <div className="flex items-center justify-center h-full"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>;
+  }
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2"><Brain className="h-6 w-6" />AI Context</h1>
+        <p className="text-sm text-muted-foreground">Project brief and brand voice — gives AI agents the full picture of your project.</p>
+      </div>
+
+      {/* Project Brief */}
+      <div className="space-y-3">
+        <div>
+          <h2 className="text-base font-semibold">Project Brief</h2>
+          <p className="text-xs text-muted-foreground">Business context, target audience, USPs, goals</p>
+        </div>
+        <Textarea
+          className="min-h-[250px] font-mono text-sm"
+          placeholder={"# Project Brief\n\n## About the Business\nWhat does the business do?\n\n## Target Audience\nWho are we writing for?\n\n## Goals\nWhat should the content achieve?"}
+          value={projectBrief}
+          onChange={(e) => setProjectBrief(e.target.value)}
+        />
+        <Button variant="outline" size="sm" onClick={saveBrief} disabled={briefStatus === "saving"}>
+          {briefStatus === "saving" ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : briefStatus === "saved" ? <Check className="mr-1.5 h-3.5 w-3.5" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
+          {briefStatus === "saved" ? "Saved" : "Save Brief"}
+        </Button>
+      </div>
+
+      {/* Brand Voice */}
+      <div className="space-y-3">
+        <div>
+          <h2 className="text-base font-semibold">Brand Voice</h2>
+          <p className="text-xs text-muted-foreground">Tone, forbidden terms, writing style — controls how AI agents write</p>
+        </div>
+        <Textarea
+          className="min-h-[250px] font-mono text-sm"
+          placeholder={"# Brand Voice\n\n## Tone\n- Warm, supportive, knowledgeable\n\n## Forbidden Terms\n- ...\n\n## Writing Style\n- Short paragraphs, active voice"}
+          value={brandVoice}
+          onChange={(e) => setBrandVoice(e.target.value)}
+        />
+        <Button variant="outline" size="sm" onClick={saveVoice} disabled={voiceStatus === "saving"}>
+          {voiceStatus === "saving" ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : voiceStatus === "saved" ? <Check className="mr-1.5 h-3.5 w-3.5" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
+          {voiceStatus === "saved" ? "Saved" : "Save Brand Voice"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -281,9 +281,7 @@ function SettingsPageContent() {
       <Tabs defaultValue={searchParams.get("tab") ?? "general"}>
         <TabsList className="flex-wrap">
           <TabsTrigger value="general">General</TabsTrigger>
-          <TabsTrigger value="ai-context">AI Context</TabsTrigger>
           <TabsTrigger value="connector-data">Connector Data</TabsTrigger>
-          <TabsTrigger value="competitors">Competitors</TabsTrigger>
           <TabsTrigger value="pipeline">Pipeline</TabsTrigger>
         </TabsList>
 
@@ -353,44 +351,6 @@ function SettingsPageContent() {
         </TabsContent>
 
         {/* AI Context (Project Brief + Brand Voice) */}
-        <TabsContent value="ai-context" className="mt-6 space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Project Brief</CardTitle>
-              <CardDescription>
-                Business context, target audience, USPs, goals — gives AI agents the full picture
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <Textarea
-                className="min-h-[300px] font-mono text-sm"
-                placeholder={`# Project Brief\n\n## About the Business\nWhat does the business do?\n\n## Target Audience\nWho are we writing for?\n\n## Unique Selling Points\n- USP 1\n- USP 2\n\n## Goals\nWhat should the content achieve?`}
-                value={projectBriefContent}
-                onChange={(e) => setProjectBriefContent(e.target.value)}
-              />
-              <SaveButton status={projectBriefStatus} onClick={saveProjectBrief} />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Brand Voice</CardTitle>
-              <CardDescription>
-                Tone, forbidden terms, writing style — controls how AI agents write
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <Textarea
-                className="min-h-[300px] font-mono text-sm"
-                placeholder={`# Brand Voice\n\n## Tone\n- Warm, supportive, knowledgeable\n\n## Forbidden Terms\n- ...\n\n## Writing Style\n- Short paragraphs, active voice`}
-                value={brandVoiceContent}
-                onChange={(e) => setBrandVoiceContent(e.target.value)}
-              />
-              <SaveButton status={brandVoiceStatus} onClick={saveBrandVoice} />
-            </CardContent>
-          </Card>
-        </TabsContent>
-
         {/* Connector Data (Authors + Categories, read-only) */}
         <TabsContent value="connector-data" className="mt-6 space-y-6">
           <div className="flex items-center justify-between">
@@ -475,73 +435,6 @@ function SettingsPageContent() {
         </TabsContent>
 
         {/* Competitors */}
-        <TabsContent value="competitors" className="mt-6 space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-lg font-semibold">Competitors</h3>
-              <p className="text-sm text-muted-foreground">
-                Used by the strategy agent for competitive analysis
-              </p>
-            </div>
-            <Button variant="outline" size="sm" onClick={addCompetitor}>
-              <Plus className="mr-2 h-3 w-3" />
-              Add Competitor
-            </Button>
-          </div>
-          {competitors.length === 0 && (
-            <div className="rounded-md border border-dashed p-8 text-center">
-              <p className="text-sm text-muted-foreground">No competitors configured yet</p>
-              <Button variant="outline" size="sm" className="mt-3" onClick={addCompetitor}>
-                <Plus className="mr-2 h-3 w-3" />
-                Add First Competitor
-              </Button>
-            </div>
-          )}
-          {competitors.map((comp, idx) => (
-            <Card key={idx}>
-              <CardContent className="p-4">
-                <div className="flex items-start gap-4">
-                  <div className="flex-1 grid grid-cols-2 gap-3">
-                    <div className="space-y-1">
-                      <Label className="text-xs text-muted-foreground">Domain</Label>
-                      <Input
-                        value={comp.domain}
-                        onChange={(e) => updateCompetitor(idx, "domain", e.target.value)}
-                        placeholder="headspace.com"
-                        className="h-8"
-                      />
-                    </div>
-                    <div className="space-y-1">
-                      <Label className="text-xs text-muted-foreground">Name</Label>
-                      <Input
-                        value={comp.name}
-                        onChange={(e) => updateCompetitor(idx, "name", e.target.value)}
-                        placeholder="Headspace"
-                        className="h-8"
-                      />
-                    </div>
-                    <div className="col-span-2 space-y-1">
-                      <Label className="text-xs text-muted-foreground">Notes</Label>
-                      <Input
-                        value={comp.notes ?? ""}
-                        onChange={(e) => updateCompetitor(idx, "notes", e.target.value)}
-                        placeholder="Market leader, strong blog presence"
-                        className="h-8"
-                      />
-                    </div>
-                  </div>
-                  <Button variant="ghost" size="icon" className="mt-5" onClick={() => removeCompetitor(idx)}>
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-          {competitors.length > 0 && (
-            <SaveButton status={competitorsStatus} onClick={saveCompetitors} />
-          )}
-        </TabsContent>
-
         {/* Pipeline */}
         <TabsContent value="pipeline" className="mt-6">
           <Card>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -310,6 +310,18 @@ export function Sidebar() {
             <TrendingUp className="h-4 w-4" />
             Trends
           </Link>
+          <Link
+            href="/intelligence/context"
+            className={cn(
+              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              pathname === "/intelligence/context"
+                ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+            )}
+          >
+            <Brain className="h-4 w-4" />
+            AI Context
+          </Link>
         </div>
       </div>
 

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   BarChart3,
   Brain,
   FileText,
+  Inbox,
   Layers,
   Mail,
   MessageSquare,
@@ -64,6 +65,7 @@ export function Sidebar() {
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [cmoOpen, setCmoOpen] = useState(false);
+  const [inboxCount, setInboxCount] = useState(0);
   const [renameValue, setRenameValue] = useState("");
   const [deleteFlowId, setDeleteFlowId] = useState<string | null>(null);
 
@@ -78,6 +80,16 @@ export function Sidebar() {
   }, [customerId, projectId]);
 
   useEffect(() => { loadFlows(); }, [loadFlows]);
+
+  // Load inbox count
+  useEffect(() => {
+    if (!customerId || !projectId) return;
+    const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:6100";
+    fetch(`${API}/customers/${customerId}/projects/${projectId}/ideas`)
+      .then((r) => r.ok ? r.json() : [])
+      .then((ideas: Array<{ status: string }>) => setInboxCount(ideas.filter((i) => i.status === "inbox").length))
+      .catch(() => {});
+  }, [customerId, projectId, pathname]);
 
   // Reload flows on navigation and custom events
   useEffect(() => {
@@ -241,8 +253,25 @@ export function Sidebar() {
         </div>
       ) : (
       <>
+      {/* Inbox */}
+      <div className="px-3 pt-3 pb-1">
+        <Link
+          href="/inbox"
+          className={cn(
+            "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+            pathname === "/inbox"
+              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+          )}
+        >
+          <Inbox className="h-4 w-4" />
+          Inbox
+          {inboxCount > 0 && <span className="ml-auto text-xs bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 leading-none">{inboxCount}</span>}
+        </Link>
+      </div>
+
       {/* Content Section */}
-      <div className="px-3 pt-4 pb-1">
+      <div className="px-3 pt-2 pb-1">
         <div className="px-3 pb-2">
           <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Content</span>
         </div>

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -178,19 +178,16 @@ export function Sidebar() {
 
   return (
     <aside className="flex h-screen w-64 flex-col border-r bg-sidebar text-sidebar-foreground">
-      {/* Logo */}
-      <Link href="/content/articles" className="flex items-center gap-2.5 border-b px-4 py-4 hover:bg-muted/50 transition-colors">
-        <Image src="/logo.png" alt="FlowBoost" width={28} height={28} className="rounded-md" />
-        <span className="text-lg font-semibold">flowboost</span>
-      </Link>
-
-      {/* Project Selector */}
-      <div className="border-b px-3 py-3">
+      {/* Logo + Project Selector */}
+      <div className="flex items-center gap-2 border-b px-3 py-2.5">
+        <Link href="/content/articles" className="shrink-0">
+          <Image src="/logo.png" alt="FlowBoost" width={28} height={28} className="rounded-md" />
+        </Link>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="w-full justify-between font-medium">
-              {project?.name ?? "Loading..."}
-              <ChevronDown className="h-4 w-4 opacity-50" />
+            <Button variant="ghost" size="sm" className="flex-1 justify-between font-medium h-8 px-2">
+              <span className="truncate">{project?.name ?? "Loading..."}</span>
+              <ChevronDown className="h-3.5 w-3.5 opacity-50 shrink-0 ml-1" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-56">
@@ -211,6 +208,39 @@ export function Sidebar() {
         </DropdownMenu>
       </div>
 
+      {/* Browse / Chat Tabs */}
+      <div className="px-3 py-2 border-b">
+        <div className="flex bg-muted/60 rounded-lg p-0.5">
+          <button
+            type="button"
+            onClick={() => setCmoOpen(false)}
+            className={cn(
+              "flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors",
+              !cmoOpen ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Library className="h-3.5 w-3.5" />Browse
+          </button>
+          <button
+            type="button"
+            onClick={() => setCmoOpen(true)}
+            className={cn(
+              "flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors",
+              cmoOpen ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <MessageSquare className="h-3.5 w-3.5" />Chat
+          </button>
+        </div>
+      </div>
+
+      {/* Chat Mode — replaces navigation */}
+      {cmoOpen && customerId && projectId ? (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <CmoChat customerId={customerId} projectId={projectId} />
+        </div>
+      ) : (
+      <>
       {/* Content Section */}
       <div className="px-3 pt-4 pb-1">
         <div className="px-3 pb-2">
@@ -313,8 +343,8 @@ export function Sidebar() {
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Monitor + CMO Chat */}
-      <div className="px-3 pb-1 space-y-0.5">
+      {/* Monitor */}
+      <div className="px-3 pb-1">
         <Link
           href="/monitor"
           className={cn(
@@ -327,15 +357,10 @@ export function Sidebar() {
           <Activity className="h-4 w-4" />
           Monitor
         </Link>
-        <button
-          type="button"
-          onClick={() => setCmoOpen(true)}
-          className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors w-full text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
-        >
-          <MessageSquare className="h-4 w-4" />
-          CMO Chat
-        </button>
       </div>
+
+      </>
+      )}
 
       {/* Footer */}
       <div className="border-t px-4 py-3 text-xs text-muted-foreground flex items-center gap-2">
@@ -374,23 +399,6 @@ export function Sidebar() {
         </DialogContent>
       </Dialog>
 
-      {/* CMO Chat Overlay */}
-      {cmoOpen && customerId && projectId && (
-        <div className="fixed inset-0 z-50 flex justify-end">
-          <div className="absolute inset-0 bg-black/20" onClick={() => setCmoOpen(false)} />
-          <div className="relative w-full max-w-md bg-background border-l shadow-xl flex flex-col h-full animate-in slide-in-from-right duration-200">
-            <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
-              <h3 className="text-sm font-semibold flex items-center gap-1.5">
-                <MessageSquare className="h-3.5 w-3.5" />CMO Chat
-              </h3>
-              <button type="button" onClick={() => setCmoOpen(false)} className="p-1.5 rounded-md hover:bg-muted text-muted-foreground">
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <CmoChat customerId={customerId} projectId={projectId} />
-          </div>
-        </div>
-      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Inbox for idea collection with labels (article/linkedin/instagram/x/tiktok/newsletter) and archive
- Intelligence: page-extracted categories only (no AI guessing, $0/scan)
- Intelligence: AI Context page, competitors API fallback, H3 dedup, URL normalization
- Crawler: Playwright blog fallback discovery, single-competitor re-scan
- Settings: competitors + AI context moved to Intelligence section
- Sidebar: Inbox with count badge, PostHog-style Browse/Chat tabs